### PR TITLE
ref(deis): change image destination to deisci/postgres

### DIFF
--- a/deis/manifests/deis-database-rc.yaml
+++ b/deis/manifests/deis-database-rc.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: deis-database
-          image: quay.io/deisci/database:v2-alpha
+          image: quay.io/deisci/postgres:v2-alpha
           imagePullPolicy: Always
           env:
             - name: POSTGRES_USER


### PR DESCRIPTION
deis/postgres is now deploying the image name as deisci/postgres.
We are still pending discussion if the rest of the chart will need
to be renamed to deis-postgres, but for now this reflects the latest
version of deis/postgres.

See deis/postgres#12
