### PR TITLE
ref(deis): make workflow service listen on port 80

### DIFF
--- a/deis/manifests/deis-workflow-service.yaml
+++ b/deis/manifests/deis-workflow-service.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   ports:
     - name: http
-      port: 8000
+      port: 80
+      targetPort: 8000
   selector:
     name: deis-workflow


### PR DESCRIPTION
This will change deis clients to use `deis login $SERVICE_IP` instead of
`deis login $SERVICE_IP:8000`.
