### PR TITLE
chore(router): prefix annotations with deis.com/

### DIFF
--- a/deis/manifests/deis-router-rc.yaml
+++ b/deis/manifests/deis-router-rc.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     heritage: deis
   annotations:
-    routerConfig: |
+    deis.com/routerConfig: |
       {
         "useProxyProtocol": false
       }


### PR DESCRIPTION
Suggested by @technosophos 

Requires [this router PR](https://github.com/deis/router/pull/24) to also be merged.
