### PR TITLE
feat(workflow): make workflow routable

### DIFF
--- a/deis/manifests/deis-router-rc.yaml
+++ b/deis/manifests/deis-router-rc.yaml
@@ -6,8 +6,9 @@ metadata:
   labels:
     heritage: deis
   annotations:
-    deis.com/routerConfig: |
+    deis.io/routerConfig: |
       {
+        "domain": "example.com",
         "useProxyProtocol": false
       }
 spec:

--- a/deis/manifests/deis-workflow-service.yaml
+++ b/deis/manifests/deis-workflow-service.yaml
@@ -5,6 +5,12 @@ metadata:
   namespace: deis
   labels:
     heritage: deis
+    routable: "true"
+  annotations:
+    deis.io/routerConfig: |
+      {
+        "domains": [ "deis" ]
+      }
 spec:
   ports:
     - name: http


### PR DESCRIPTION
Make workflow "routable--" meaning the router can send traffic its way.  Note that there is no special support in the router for this, whatsoever.  From the router's perspective, workflow is just another routable app.

This requires all of the following to also be merged:
- deis/router#23
- deis/router#24
- #21 
