### PR TITLE
chore(router): switch to using .io in annotation prefixes

### DIFF
--- a/deis/manifests/deis-router-rc.yaml
+++ b/deis/manifests/deis-router-rc.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     heritage: deis
   annotations:
-    deis.com/routerConfig: |
+    deis.io/routerConfig: |
       {
         "useProxyProtocol": false
       }


### PR DESCRIPTION
See conversation in deis/router#24
