### PR TITLE
feat(router): add support for non-proxy-proto healthz

### DIFF
--- a/deis/manifests/deis-router-rc.yaml
+++ b/deis/manifests/deis-router-rc.yaml
@@ -37,3 +37,5 @@ spec:
           hostPort: 443
         - containerPort: 2222
           hostPort: 2222
+        - containerPort: 9090
+          hostPort: 9090


### PR DESCRIPTION
deis/router#45 added router healthchecks.  As in v1.x, we expose an auxiliary healthcheck on port 9090 that never uses PROXY protocol, even when it is used elsewhere.  This allows an ELB, for instance, to carry out router healthchecks over http, when otherwise it could not.
