### PR TITLE
fix(minio): use deisci/minio:v2-alpha image

### DIFF
--- a/deis/manifests/deis-minio-rc.yaml
+++ b/deis/manifests/deis-minio-rc.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: deis-minio
-          image: quay.io/deis/minio
+          image: quay.io/deisci/minio:v2-alpha
           imagePullPolicy: Always
           ports:
             - containerPort: 9000


### PR DESCRIPTION
This updates the `image:` to reference what is actually automated for the v2 alpha.
