### PR TITLE
fix(deis-builder-service.yaml): change selector to name

### DIFF
--- a/deis/manifests/deis-builder-service.yaml
+++ b/deis/manifests/deis-builder-service.yaml
@@ -10,4 +10,4 @@ spec:
     - name: ssh
       port: 2222
   selector:
-    app: deis-builder
+    name: deis-builder


### PR DESCRIPTION
The current manifest for the `deis-builder` service results in no endpoints (see output below) because it has the wrong selector. Fixes #32

``` console
ENG000656:workflow aaronschlesinger$ kubectl --namespace=deis describe svc deis-builder
Name:           deis-builder
Namespace:      deis
Labels:         heritage=deis
Selector:       app=deis-builder
Type:           ClusterIP
IP:         10.3.0.11
Port:           ssh 2222/TCP
Endpoints:      <none>
Session Affinity:   None
No events.
```
