### PR TITLE
chore(workflow): tweak workflow router config to match v1.x

### DIFF
--- a/deis/manifests/deis-workflow-service.yaml
+++ b/deis/manifests/deis-workflow-service.yaml
@@ -9,7 +9,9 @@ metadata:
   annotations:
     deis.io/routerConfig: |
       {
-        "domains": [ "deis" ]
+        "domains": [ "deis" ],
+        "connectTimeout": 10,
+        "tcpTimeout": 1200
       }
 spec:
   ports:


### PR DESCRIPTION
This updates router configuration for workflow to match the reduced connect timeout and increased tcp timeout used by the controller's router configs in v1.x.

These won't take effect until deis/router#52 is merged, but this PR won't harm anything if it is merged before then.
