### PR TITLE
feat(router): add service for router

### DIFF
--- a/deis/manifests/deis-router-service.yaml
+++ b/deis/manifests/deis-router-service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: deis-router
+  namespace: deis
+  labels:
+    heritage: deis
+spec:
+  type: LoadBalancer
+  selector:
+    app: deis-router
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+    - name: https
+      port: 443
+      targetPort: 443
+    - name: builder
+      port: 2222
+      targetPort: 2222
+    - name: healthz
+      port: 9090
+      targetPort: 9090


### PR DESCRIPTION
This adds a service of `type: LoadBalancer` to the chart.  This is the _primary_ of two possible strategies for exposing the router(s) for ingress from outside the cluster.  `type: LoadBalancer` will compel k8s to create a load balancer external to the cluster where supported.  For instance, this usually works fine on GKE or most k8s distributions running on AWS.

For infrastructure with a k8s "cloud provider," the functions that support this are implemented as no-ops, meaning there should be no harm from applying this on bare metal or Vagrant, for instance, where this service will simply have no effect.

For such cases, we'll have to document a secondary option for getting incoming traffic to the router.  I'm not sure where that documentation goes since charts don't seem to have their own docs.

fwiw, the fallback option is to manually create a load balancer that pipes 80 -> 80, 443 -> 443, 2222 -> 2222, and 9090 -> 9090, with a healthcheck using HTTP on `9090:/healthz`.  Router instances take up those ports on any host they run on.  Just those instances will pass the healthcheck and will therefore be load balanced.  This is the same strategy that was used in Deis v1.x.
