### PR TITLE
fix(*): use standard app labels & selectors, add heritage label where necessary [WIP]

### DIFF
--- a/deis-dev/manifests/deis-builder-rc.yaml
+++ b/deis-dev/manifests/deis-builder-rc.yaml
@@ -8,11 +8,11 @@ metadata:
 spec:
   replicas: 1
   selector:
-    name: deis-builder
+    app: deis-builder
   template:
     metadata:
       labels:
-        name: deis-builder
+        app: deis-builder
     spec:
       containers:
         - name: deis-builder

--- a/deis-dev/manifests/deis-builder-service.yaml
+++ b/deis-dev/manifests/deis-builder-service.yaml
@@ -11,4 +11,4 @@ spec:
       port: 2222
       targetPort: 2223
   selector:
-    name: deis-builder
+    app: deis-builder

--- a/deis-dev/manifests/deis-database-rc.yaml
+++ b/deis-dev/manifests/deis-database-rc.yaml
@@ -8,11 +8,11 @@ metadata:
 spec:
   replicas: 1
   selector:
-    name: deis-database
+    app: deis-database
   template:
     metadata:
       labels:
-        name: deis-database
+        app: deis-database
     spec:
       containers:
         - name: deis-database

--- a/deis-dev/manifests/deis-database-service.yaml
+++ b/deis-dev/manifests/deis-database-service.yaml
@@ -10,4 +10,4 @@ spec:
     - name: http
       port: 5432
   selector:
-    name: deis-database
+    app: deis-database

--- a/deis-dev/manifests/deis-etcd-discovery-rc.yaml
+++ b/deis-dev/manifests/deis-etcd-discovery-rc.yaml
@@ -8,11 +8,11 @@ metadata:
 spec:
   replicas: 1
   selector:
-    name: deis-etcd-discovery
+    app: deis-etcd-discovery
   template:
     metadata:
       labels:
-        name: deis-etcd-discovery
+        app: deis-etcd-discovery
     spec:
       volumes:
         - name: discovery-token

--- a/deis-dev/manifests/deis-etcd-discovery-rc.yaml
+++ b/deis-dev/manifests/deis-etcd-discovery-rc.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: deis
   labels:
     name: deis-etcd-discovery
+    heritage: deis
 spec:
   replicas: 1
   selector:

--- a/deis-dev/manifests/deis-etcd-discovery-service.yaml
+++ b/deis-dev/manifests/deis-etcd-discovery-service.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     name: deis-etcd-discovery
     app: deis
+    heritage: deis
 spec:
   ports:
     - name: client

--- a/deis-dev/manifests/deis-etcd-discovery-service.yaml
+++ b/deis-dev/manifests/deis-etcd-discovery-service.yaml
@@ -11,4 +11,4 @@ spec:
     - name: client
       port: 2381
   selector:
-    name: deis-etcd-discovery
+    app: deis-etcd-discovery

--- a/deis-dev/manifests/deis-etcd-discovery-token.yaml
+++ b/deis-dev/manifests/deis-etcd-discovery-token.yaml
@@ -3,5 +3,7 @@ apiVersion: v1
 metadata:
   name: deis-etcd-discovery-token
   namespace: deis
+  labels:
+    heritage: deis
 data:
   token: "RTJENjQ1NzYtRDU0Ny00OThDLUFGNzEtM0NGNkVGMzE5QThCCg=="

--- a/deis-dev/manifests/deis-etcd-rc.yaml
+++ b/deis-dev/manifests/deis-etcd-rc.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: deis
   labels:
     name: deis-etcd-1
+    heritage: deis
 spec:
   replicas: 3
   selector:

--- a/deis-dev/manifests/deis-etcd-rc.yaml
+++ b/deis-dev/manifests/deis-etcd-rc.yaml
@@ -8,11 +8,11 @@ metadata:
 spec:
   replicas: 3
   selector:
-    name: deis-etcd-1
+    app: deis-etcd-1
   template:
     metadata:
       labels:
-        name: deis-etcd-1
+        app: deis-etcd-1
     spec:
       volumes:
         - name: discovery-token

--- a/deis-dev/manifests/deis-etcd-service.yaml
+++ b/deis-dev/manifests/deis-etcd-service.yaml
@@ -14,4 +14,4 @@ spec:
     - name: client
       port: 4100
   selector:
-    name: deis-etcd-1
+    app: deis-etcd-1

--- a/deis-dev/manifests/deis-etcd-service.yaml
+++ b/deis-dev/manifests/deis-etcd-service.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     name: deis-etcd-1
     app: deis
+    heritage: deis
 spec:
   ports:
     - name: peer

--- a/deis-dev/manifests/deis-registry-rc.yaml
+++ b/deis-dev/manifests/deis-registry-rc.yaml
@@ -8,11 +8,11 @@ metadata:
 spec:
   replicas: 1
   selector:
-    name: deis-registry
+    app: deis-registry
   template:
     metadata:
       labels:
-        name: deis-registry
+        app: deis-registry
     spec:
       containers:
         - name: deis-registry

--- a/deis-dev/manifests/deis-registry-service.yaml
+++ b/deis-dev/manifests/deis-registry-service.yaml
@@ -10,4 +10,4 @@ spec:
     - name: http
       port: 5000
   selector:
-    name: deis-registry
+    app: deis-registry

--- a/deis-dev/manifests/deis-workflow-rc.yaml
+++ b/deis-dev/manifests/deis-workflow-rc.yaml
@@ -8,11 +8,11 @@ metadata:
 spec:
   replicas: 1
   selector:
-    name: deis-workflow
+    app: deis-workflow
   template:
     metadata:
       labels:
-        name: deis-workflow
+        app: deis-workflow
     spec:
       containers:
         - name: deis-workflow

--- a/deis-dev/manifests/deis-workflow-service.yaml
+++ b/deis-dev/manifests/deis-workflow-service.yaml
@@ -16,4 +16,4 @@ spec:
       port: 80
       targetPort: 8000
   selector:
-    name: deis-workflow
+    app: deis-workflow

--- a/deis/manifests/deis-builder-rc.yaml
+++ b/deis/manifests/deis-builder-rc.yaml
@@ -8,11 +8,11 @@ metadata:
 spec:
   replicas: 1
   selector:
-    name: deis-builder
+    app: deis-builder
   template:
     metadata:
       labels:
-        name: deis-builder
+        app: deis-builder
     spec:
       containers:
         - name: deis-builder

--- a/deis/manifests/deis-builder-service.yaml
+++ b/deis/manifests/deis-builder-service.yaml
@@ -11,4 +11,4 @@ spec:
       port: 2222
       targetPort: 2223
   selector:
-    name: deis-builder
+    app: deis-builder

--- a/deis/manifests/deis-database-rc.yaml
+++ b/deis/manifests/deis-database-rc.yaml
@@ -8,11 +8,11 @@ metadata:
 spec:
   replicas: 1
   selector:
-    name: deis-database
+    app: deis-database
   template:
     metadata:
       labels:
-        name: deis-database
+        app: deis-database
     spec:
       containers:
         - name: deis-database

--- a/deis/manifests/deis-database-service.yaml
+++ b/deis/manifests/deis-database-service.yaml
@@ -10,4 +10,4 @@ spec:
     - name: http
       port: 5432
   selector:
-    name: deis-database
+    app: deis-database

--- a/deis/manifests/deis-etcd-discovery-rc.yaml
+++ b/deis/manifests/deis-etcd-discovery-rc.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       labels:
-        name: deis-etcd-discovery
+        app: deis-etcd-discovery
     spec:
       volumes:
         - name: discovery-token

--- a/deis/manifests/deis-etcd-discovery-rc.yaml
+++ b/deis/manifests/deis-etcd-discovery-rc.yaml
@@ -4,11 +4,11 @@ metadata:
   name: deis-etcd-discovery
   namespace: deis
   labels:
-    name: deis-etcd-discovery
+    heritage: deis
 spec:
   replicas: 1
   selector:
-    name: deis-etcd-discovery
+    app: deis-etcd-discovery
   template:
     metadata:
       labels:

--- a/deis/manifests/deis-etcd-discovery-service.yaml
+++ b/deis/manifests/deis-etcd-discovery-service.yaml
@@ -4,11 +4,10 @@ metadata:
   name: deis-etcd-discovery
   namespace: deis
   labels:
-    name: deis-etcd-discovery
-    app: deis
+    heritage: deis
 spec:
   ports:
     - name: client
       port: 2381
   selector:
-    name: deis-etcd-discovery
+    app: deis-etcd-discovery

--- a/deis/manifests/deis-etcd-rc.yaml
+++ b/deis/manifests/deis-etcd-rc.yaml
@@ -4,15 +4,15 @@ metadata:
   name: deis-etcd-1
   namespace: deis
   labels:
-    name: deis-etcd-1
+    heritage: deis
 spec:
   replicas: 3
   selector:
-    name: deis-etcd-1
+    app: deis-etcd-1
   template:
     metadata:
       labels:
-        name: deis-etcd-1
+        app: deis-etcd-1
     spec:
       containers:
         - name: deis-etcd-1

--- a/deis/manifests/deis-etcd-service.yaml
+++ b/deis/manifests/deis-etcd-service.yaml
@@ -5,8 +5,6 @@ metadata:
   namespace: deis
   labels:
     heritage: deis
-    name: deis-etcd-1
-    app: deis
 spec:
   ports:
     - name: peer

--- a/deis/manifests/deis-etcd-service.yaml
+++ b/deis/manifests/deis-etcd-service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: deis-etcd-1
   namespace: deis
   labels:
+    heritage: deis
     name: deis-etcd-1
     app: deis
 spec:
@@ -14,4 +15,4 @@ spec:
     - name: client
       port: 4100
   selector:
-    name: deis-etcd-1
+    app: deis-etcd-1

--- a/deis/manifests/deis-registry-rc.yaml
+++ b/deis/manifests/deis-registry-rc.yaml
@@ -8,11 +8,11 @@ metadata:
 spec:
   replicas: 1
   selector:
-    name: deis-registry
+    app: deis-registry
   template:
     metadata:
       labels:
-        name: deis-registry
+        app: deis-registry
     spec:
       containers:
         - name: deis-registry

--- a/deis/manifests/deis-registry-service.yaml
+++ b/deis/manifests/deis-registry-service.yaml
@@ -10,4 +10,4 @@ spec:
     - name: http
       port: 5000
   selector:
-    name: deis-registry
+    app: deis-registry

--- a/deis/manifests/deis-workflow-rc.yaml
+++ b/deis/manifests/deis-workflow-rc.yaml
@@ -8,11 +8,11 @@ metadata:
 spec:
   replicas: 1
   selector:
-    name: deis-workflow
+    app: deis-workflow
   template:
     metadata:
       labels:
-        name: deis-workflow
+        app: deis-workflow
     spec:
       containers:
         - name: deis-workflow

--- a/deis/manifests/deis-workflow-service.yaml
+++ b/deis/manifests/deis-workflow-service.yaml
@@ -19,4 +19,4 @@ spec:
       port: 80
       targetPort: 8000
   selector:
-    name: deis-workflow
+    app: deis-workflow


### PR DESCRIPTION
This PR changes all manifests to use standard `app` labels and selectors where appropriate. It also adds `heritage` labels where they're missing.

Fixes #40 
