### PR TITLE
doc(readme): update readme for accuracy + new components

### DIFF
--- a/deis/README.md
+++ b/deis/README.md
@@ -5,7 +5,12 @@ components are not HA, and there are likely to be bugs.
 
 Please report any issues you find in testing Deis v2 on Kubernetes
 to the appropriate GitHub repository:
+- builder: https://github.com/deis/builder
 - chart: https://github.com/deis/charts
-- helm: https://github.com/deis/helm
-- workflow: https://github.com/deis/workflow
+- database: https://github.com/deis/postgres
 - etcd: https://github.com/deis/etcd
+- helm: https://github.com/helm/helm
+- minio: https://github.com/deis/minio
+- registry: https://github.com/deis/registry
+- router: https://github.com/deis/router
+- workflow: https://github.com/deis/workflow


### PR DESCRIPTION
This adds missing component -> repo mappings to the readme, corrects the address of the helm repo (since it moved), and organizes the list of components alphabetically.
