### PR TITLE
feat(manifests): add k8s readiness check

### DIFF
--- a/deis/manifests/deis-workflow-rc.yaml
+++ b/deis/manifests/deis-workflow-rc.yaml
@@ -18,6 +18,12 @@ spec:
         - name: deis-workflow
           image: quay.io/deis/workflow:2.0.0-alpha
           imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /health-check
+              port: 8000
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
           env:
             - name: DEIS_DATABASE_USER
               value: deis


### PR DESCRIPTION
Adds a k8s [readiness check](http://kubernetes.io/v1.1/docs/user-guide/production-pods.html#liveness-and-readiness-probes-aka-health-checks) to workflow, in addition to the existing [liveness check](https://github.com/deis/charts/pull/35).
