### PR TITLE
feat(charts): add Deis-Lite Chart

### DIFF
--- a/deis-lite/Chart.yaml
+++ b/deis-lite/Chart.yaml
@@ -1,0 +1,12 @@
+name: deis-lite
+home: https://github.com/deis/workflow
+version: 2.0.0-alpha
+description: For testing only!
+maintainers:
+- Rimas Mocevicius <rimas@deis.com>
+details: |-
+  Deis-Lite v2.0.0 alpha is Kubernetes one node setup, with a persistent setup via host folders.
+
+  Deis (pronounced DAY-iss) is an open source PaaS that makes it easy to deploy
+  and manage applications on your own servers. Deis builds on Kubernetes
+  to provide a lightweight, Heroku-inspired workflow.

--- a/deis-lite/README.md
+++ b/deis-lite/README.md
@@ -1,0 +1,25 @@
+# Deis-Lite v2.0.0-alpha
+
+Deis-Lite is Kubernetes one node setup, it has a persistent setup via host folders.
+
+#### Currently works on:
+- Kube-solo App - https://github.com/TheNewNormal/kube-solo-osx, where you can install it with just simple console command `$ install_deis`
+
+Instructions for installing a Deis cluster:
+https://github.com/deis/charts
+
+Complete instructions for installing and managing a Deis cluster:
+https://github.com/deis/workflow/tree/master/docs/src
+
+
+Please report any issues you find in testing Deis v2 on Kubernetes
+to the appropriate GitHub repository:
+- builder: https://github.com/deis/builder
+- chart: https://github.com/deis/charts
+- database: https://github.com/deis/postgres
+- etcd: https://github.com/deis/etcd
+- helm: https://github.com/helm/helm
+- minio: https://github.com/deis/minio
+- registry: https://github.com/deis/registry
+- router: https://github.com/deis/router
+- workflow: https://github.com/deis/workflow

--- a/deis-lite/manifests/deis-builder-rc.yaml
+++ b/deis-lite/manifests/deis-builder-rc.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: deis-builder
+  namespace: deis
+  labels:
+    heritage: deis
+spec:
+  replicas: 1
+  selector:
+    name: deis-builder
+  template:
+    metadata:
+      labels:
+        name: deis-builder
+    spec:
+      containers:
+        - name: deis-builder
+          image: quay.io/deis/builder:2.0.0-alpha
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 2223
+              name: ssh
+            - containerPort: 3000
+              name: fetcher
+          env:
+            - name: "EXTERNAL_PORT"
+              value: "2223"
+            # This var needs to be passed so that the minio client (https://github.com/minio/mc) will work in Alpine linux
+            - name: "DOCKERIMAGE"
+              value: "1"
+            - name: "POD_NAMESPACE"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: minio-user
+              mountPath: /var/run/secrets/object/store
+              readOnly: true
+      volumes:
+        - name: minio-user
+          secret:
+            secretName: minio-user

--- a/deis-lite/manifests/deis-builder-rc.yaml
+++ b/deis-lite/manifests/deis-builder-rc.yaml
@@ -8,11 +8,11 @@ metadata:
 spec:
   replicas: 1
   selector:
-    name: deis-builder
+    app: deis-builder
   template:
     metadata:
       labels:
-        name: deis-builder
+        app: deis-builder
     spec:
       containers:
         - name: deis-builder

--- a/deis-lite/manifests/deis-builder-service.yaml
+++ b/deis-lite/manifests/deis-builder-service.yaml
@@ -11,4 +11,4 @@ spec:
       port: 2222
       targetPort: 2223
   selector:
-    name: deis-builder
+    app: deis-builder

--- a/deis-lite/manifests/deis-builder-service.yaml
+++ b/deis-lite/manifests/deis-builder-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: deis-builder
+  namespace: deis
+  labels:
+    heritage: deis
+spec:
+  ports:
+    - name: ssh
+      port: 2222
+      targetPort: 2223
+  selector:
+    name: deis-builder

--- a/deis-lite/manifests/deis-database-rc.yaml
+++ b/deis-lite/manifests/deis-database-rc.yaml
@@ -8,11 +8,11 @@ metadata:
 spec:
   replicas: 1
   selector:
-    name: deis-database
+    app: deis-database
   template:
     metadata:
       labels:
-        name: deis-database
+        app: deis-database
     spec:
       containers:
         - name: deis-database

--- a/deis-lite/manifests/deis-database-rc.yaml
+++ b/deis-lite/manifests/deis-database-rc.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: deis-database
+  namespace: deis
+  labels:
+    heritage: deis
+spec:
+  replicas: 1
+  selector:
+    name: deis-database
+  template:
+    metadata:
+      labels:
+        name: deis-database
+    spec:
+      containers:
+        - name: deis-database
+          image: quay.io/deis/postgres:2.0.0-alpha
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POSTGRES_USER
+              value: "deis"
+            - name: POSTGRES_PASSWORD
+              value: "changeme123"
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - name: postgresql-data
+              mountPath: /app/data
+      volumes:
+        - name: postgresql-data
+          hostPath:
+            path: /data/deis/postgresql

--- a/deis-lite/manifests/deis-database-service.yaml
+++ b/deis-lite/manifests/deis-database-service.yaml
@@ -10,4 +10,4 @@ spec:
     - name: http
       port: 5432
   selector:
-    name: deis-database
+    app: deis-database

--- a/deis-lite/manifests/deis-database-service.yaml
+++ b/deis-lite/manifests/deis-database-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: deis-database
+  namespace: deis
+  labels:
+    heritage: deis
+spec:
+  ports:
+    - name: http
+      port: 5432
+  selector:
+    name: deis-database

--- a/deis-lite/manifests/deis-etcd-discovery-rc.yaml
+++ b/deis-lite/manifests/deis-etcd-discovery-rc.yaml
@@ -1,0 +1,45 @@
+kind: ReplicationController
+apiVersion: v1
+metadata:
+  name: deis-etcd-discovery
+  namespace: deis
+  labels:
+    name: deis-etcd-discovery
+spec:
+  replicas: 1
+  selector:
+    name: deis-etcd-discovery
+  template:
+    metadata:
+      labels:
+        name: deis-etcd-discovery
+    spec:
+      volumes:
+        - name: discovery-token
+          secret:
+            secretName: deis-etcd-discovery-token
+      containers:
+        - name: deis-etcd-discovery
+          image: quay.io/deis/etcd:2.0.0-alpha
+          imagePullPolicy: IfNotPresent
+          command:
+            - /usr/local/bin/discovery
+          ports:
+            - containerPort: 2381
+          env:
+            - name: DEIS_ETCD_CLUSTER_SIZE
+              value: "1"
+            - name: ETCD_LISTEN_CLIENT_URLS
+              value: http://0.0.0.0:2381
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          volumeMounts:
+            - name: discovery-token
+              readOnly: true
+              mountPath: /var/run/secrets/deis/etcd/discovery

--- a/deis-lite/manifests/deis-etcd-discovery-rc.yaml
+++ b/deis-lite/manifests/deis-etcd-discovery-rc.yaml
@@ -4,15 +4,15 @@ metadata:
   name: deis-etcd-discovery
   namespace: deis
   labels:
-    name: deis-etcd-discovery
+    heritage: deis
 spec:
   replicas: 1
   selector:
-    name: deis-etcd-discovery
+    app: deis-etcd-discovery
   template:
     metadata:
       labels:
-        name: deis-etcd-discovery
+        app: deis-etcd-discovery
     spec:
       volumes:
         - name: discovery-token

--- a/deis-lite/manifests/deis-etcd-discovery-service.yaml
+++ b/deis-lite/manifests/deis-etcd-discovery-service.yaml
@@ -4,11 +4,10 @@ metadata:
   name: deis-etcd-discovery
   namespace: deis
   labels:
-    name: deis-etcd-discovery
-    app: deis
+    heritage: deis
 spec:
   ports:
     - name: client
       port: 2381
   selector:
-    name: deis-etcd-discovery
+    app: deis-etcd-discovery

--- a/deis-lite/manifests/deis-etcd-discovery-service.yaml
+++ b/deis-lite/manifests/deis-etcd-discovery-service.yaml
@@ -1,0 +1,14 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: deis-etcd-discovery
+  namespace: deis
+  labels:
+    name: deis-etcd-discovery
+    app: deis
+spec:
+  ports:
+    - name: client
+      port: 2381
+  selector:
+    name: deis-etcd-discovery

--- a/deis-lite/manifests/deis-etcd-discovery-token.yaml
+++ b/deis-lite/manifests/deis-etcd-discovery-token.yaml
@@ -1,0 +1,7 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: deis-etcd-discovery-token
+  namespace: deis
+data:
+  token: "RTJENjQ1NzYtRDU0Ny00OThDLUFGNzEtM0NGNkVGMzE5QThCCg=="

--- a/deis-lite/manifests/deis-etcd-rc.yaml
+++ b/deis-lite/manifests/deis-etcd-rc.yaml
@@ -4,15 +4,15 @@ metadata:
   name: deis-etcd-1
   namespace: deis
   labels:
-    name: deis-etcd-1
+    heritage: deis-etcd-1
 spec:
   replicas: 1
   selector:
-    name: deis-etcd-1
+    app: deis-etcd-1
   template:
     metadata:
       labels:
-        name: deis-etcd-1
+        app: deis-etcd-1
     spec:
       containers:
         - name: deis-etcd-1

--- a/deis-lite/manifests/deis-etcd-rc.yaml
+++ b/deis-lite/manifests/deis-etcd-rc.yaml
@@ -1,0 +1,46 @@
+kind: ReplicationController
+apiVersion: v1
+metadata:
+  name: deis-etcd-1
+  namespace: deis
+  labels:
+    name: deis-etcd-1
+spec:
+  replicas: 1
+  selector:
+    name: deis-etcd-1
+  template:
+    metadata:
+      labels:
+        name: deis-etcd-1
+    spec:
+      containers:
+        - name: deis-etcd-1
+          image: quay.io/deis/etcd:2.0.0-alpha
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: DEIS_ETCD_CLUSTER_SIZE
+              value: "1"
+            - name: ETCD_NAME
+              value: deis1
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          volumeMounts:
+            - name: discovery-token
+              readOnly: true
+              mountPath: /var/run/secrets/deis/etcd/discovery
+            - name: var-lib-etcd2
+              mountPath: /var/lib/etcd2
+      volumes:
+        - name: discovery-token
+          secret:
+            secretName: deis-etcd-discovery-token
+        - name: var-lib-etcd2
+          hostPath:
+            path: /data/deis/etcd2

--- a/deis-lite/manifests/deis-etcd-service.yaml
+++ b/deis-lite/manifests/deis-etcd-service.yaml
@@ -4,8 +4,7 @@ metadata:
   name: deis-etcd-1
   namespace: deis
   labels:
-    name: deis-etcd-1
-    app: deis
+    heritage: deis
 spec:
   ports:
     - name: peer
@@ -14,4 +13,4 @@ spec:
     - name: client
       port: 4100
   selector:
-    name: deis-etcd-1
+    app: deis-etcd-1

--- a/deis-lite/manifests/deis-etcd-service.yaml
+++ b/deis-lite/manifests/deis-etcd-service.yaml
@@ -1,0 +1,17 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: deis-etcd-1
+  namespace: deis
+  labels:
+    name: deis-etcd-1
+    app: deis
+spec:
+  ports:
+    - name: peer
+      port: 2380
+      protocol: TCP
+    - name: client
+      port: 4100
+  selector:
+    name: deis-etcd-1

--- a/deis-lite/manifests/deis-minio-rc.yaml
+++ b/deis-lite/manifests/deis-minio-rc.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: deis-minio
+  namespace: deis
+  labels:
+    heritage: deis
+spec:
+  replicas: 1
+  selector:
+    app: deis-minio
+  template:
+    metadata:
+      labels:
+        app: deis-minio
+    spec:
+      containers:
+        - name: deis-minio
+          image: quay.io/deis/minio:2.0.0-alpha
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9000
+          command:
+            - boot
+          args:
+            - "server /home/minio/"
+          volumeMounts:
+            - name: minio-admin
+              mountPath: /var/run/secrets/deis/minio/admin
+              readOnly: true
+            - name: minio-user
+              mountPath: /var/run/secrets/deis/minio/user
+              readOnly: true
+            - name: home-minio
+              mountPath: /home/minio
+      volumes:
+        - name: minio-admin
+          secret:
+            secretName: minio-admin
+        - name: minio-user
+          secret:
+            secretName: minio-user
+        - name: home-minio
+          hostPath:
+            path: /data/deis/minio

--- a/deis-lite/manifests/deis-minio-secret-admin.yaml
+++ b/deis-lite/manifests/deis-minio-secret-admin.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-admin
+  namespace: deis
+  labels:
+    heritage: deis
+type: Opaque
+data:
+  access-key-id: YWRtaW4K
+  access-secret-key: cGRHOFJwdzBoOFF0eHliSHNNSGxrSnR6SnpaMnNDN2IyY0ZCRWduKwo=

--- a/deis-lite/manifests/deis-minio-secret-ssl.yaml
+++ b/deis-lite/manifests/deis-minio-secret-ssl.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-ssl
+  namespace: deis
+  labels:
+    heritage: deis
+type: Opaque
+data:
+  access-cert: OFRaUlkySlJXTVBUNlVNWFI2STUK
+  access-pem: Z2JzdHJPdm90TU1jZzJzTWZHVWhBNWE2RXQvRUk1QUx0SUhzb2JZawo=

--- a/deis-lite/manifests/deis-minio-secret-user.yaml
+++ b/deis-lite/manifests/deis-minio-secret-user.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-user
+  namespace: deis
+  labels:
+    heritage: deis
+type: Opaque
+data:
+  access-key-id: OFRaUlkySlJXTVBUNlVNWFI2STUK
+  access-secret-key: Z2JzdHJPdm90TU1jZzJzTWZHVWhBNWE2RXQvRUk1QUx0SUhzb2JZawo=

--- a/deis-lite/manifests/deis-minio-service.yaml
+++ b/deis-lite/manifests/deis-minio-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: deis-minio
+  namespace: deis
+  labels:
+    heritage: deis
+spec:
+  ports:
+    - name: s3
+      port: 9000
+  selector:
+    app: deis-minio

--- a/deis-lite/manifests/deis-namespace.yaml
+++ b/deis-lite/manifests/deis-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: deis
+  labels:
+    heritage: deis

--- a/deis-lite/manifests/deis-registry-rc.yaml
+++ b/deis-lite/manifests/deis-registry-rc.yaml
@@ -8,11 +8,11 @@ metadata:
 spec:
   replicas: 1
   selector:
-    name: deis-registry
+    app: deis-registry
   template:
     metadata:
       labels:
-        name: deis-registry
+        app: deis-registry
     spec:
       containers:
         - name: deis-registry

--- a/deis-lite/manifests/deis-registry-rc.yaml
+++ b/deis-lite/manifests/deis-registry-rc.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: deis-registry
+  namespace: deis
+  labels:
+    heritage: deis
+spec:
+  replicas: 1
+  selector:
+    name: deis-registry
+  template:
+    metadata:
+      labels:
+        name: deis-registry
+    spec:
+      containers:
+        - name: deis-registry
+          image: quay.io/deis/registry:2.0.0-alpha
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: REGISTRY_STORAGE_DELETE_ENABLED
+              value: "true"
+            - name: REGISTRY_LOG_LEVEL
+              value: info
+          ports:
+            - containerPort: 5000
+          volumeMounts:
+            - name: registry-storage
+              mountPath: /var/lib/registry
+      volumes:
+        - name: registry-storage
+          hostPath:
+            path: /data/deis/registry

--- a/deis-lite/manifests/deis-registry-service.yaml
+++ b/deis-lite/manifests/deis-registry-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: deis-registry
+  namespace: deis
+  labels:
+    heritage: deis
+spec:
+  ports:
+    - name: http
+      port: 5000
+  selector:
+    name: deis-registry

--- a/deis-lite/manifests/deis-registry-service.yaml
+++ b/deis-lite/manifests/deis-registry-service.yaml
@@ -10,4 +10,4 @@ spec:
     - name: http
       port: 5000
   selector:
-    name: deis-registry
+    app: deis-registry

--- a/deis-lite/manifests/deis-router-rc.yaml
+++ b/deis-lite/manifests/deis-router-rc.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: deis-router
+  namespace: deis
+  labels:
+    heritage: deis
+  annotations:
+    deis.io/routerConfig: |
+      {
+        "useProxyProtocol": false
+      }
+spec:
+  replicas: 1
+  selector:
+    app: deis-router
+  template:
+    metadata:
+      labels:
+        app: deis-router
+    spec:
+      serviceAccount: deis
+      containers:
+      - name: deis-router
+        image: quay.io/deis/router:2.0.0-alpha
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        ports:
+        - containerPort: 80
+          hostPort: 80
+        - containerPort: 443
+          hostPort: 443
+        - containerPort: 2222
+          hostPort: 2222
+        - containerPort: 9090
+          hostPort: 9090

--- a/deis-lite/manifests/deis-router-service.yaml
+++ b/deis-lite/manifests/deis-router-service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: deis-router
+  namespace: deis
+  labels:
+    heritage: deis
+spec:
+#  type: LoadBalancer
+  selector:
+    app: deis-router
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+    - name: https
+      port: 443
+      targetPort: 443
+    - name: builder
+      port: 2222
+      targetPort: 2222
+    - name: healthz
+      port: 9090
+      targetPort: 9090

--- a/deis-lite/manifests/deis-router-service.yaml
+++ b/deis-lite/manifests/deis-router-service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     heritage: deis
 spec:
-#  type: LoadBalancer
+  type: LoadBalancer
   selector:
     app: deis-router
   ports:

--- a/deis-lite/manifests/deis-service-account.yaml
+++ b/deis-lite/manifests/deis-service-account.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: deis
+  namespace: deis
+  labels:
+    heritage: deis

--- a/deis-lite/manifests/deis-workflow-rc.yaml
+++ b/deis-lite/manifests/deis-workflow-rc.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: deis-workflow
+  namespace: deis
+  labels:
+    heritage: deis
+spec:
+  replicas: 1
+  selector:
+    name: deis-workflow
+  template:
+    metadata:
+      labels:
+        name: deis-workflow
+    spec:
+      containers:
+        - name: deis-workflow
+          image: quay.io/deis/workflow:2.0.0-alpha
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: DEIS_DATABASE_USER
+              value: deis
+            - name: DEIS_DATABASE_PASSWORD
+              value: changeme123
+          ports:
+            - containerPort: 8000
+              name: http
+              # expose port to node to make workflow to be accessable from
+              hostPort: 8000
+          volumeMounts:
+            - mountPath: /var/run/docker.sock
+              name: docker-socket
+            - name: minio-user
+              mountPath: /var/run/secrets/deis/minio/user
+              readOnly: true
+      volumes:
+        - name: docker-socket
+          hostPath:
+            path: /var/run/docker.sock
+        - name: minio-user
+          secret:
+            secretName: minio-user

--- a/deis-lite/manifests/deis-workflow-rc.yaml
+++ b/deis-lite/manifests/deis-workflow-rc.yaml
@@ -8,11 +8,11 @@ metadata:
 spec:
   replicas: 1
   selector:
-    name: deis-workflow
+    app: deis-workflow
   template:
     metadata:
       labels:
-        name: deis-workflow
+        app: deis-workflow
     spec:
       containers:
         - name: deis-workflow
@@ -26,7 +26,7 @@ spec:
           ports:
             - containerPort: 8000
               name: http
-              # expose port to node to make workflow to be accessable from
+              # expose port to node to make workflow to be accessable from host
               hostPort: 8000
           volumeMounts:
             - mountPath: /var/run/docker.sock

--- a/deis-lite/manifests/deis-workflow-service.yaml
+++ b/deis-lite/manifests/deis-workflow-service.yaml
@@ -19,4 +19,4 @@ spec:
       port: 80
       targetPort: 8000
   selector:
-    name: deis-workflow
+    app: deis-workflow

--- a/deis-lite/manifests/deis-workflow-service.yaml
+++ b/deis-lite/manifests/deis-workflow-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: deis-workflow
+  namespace: deis
+  labels:
+    heritage: deis
+    routable: "true"
+  annotations:
+    deis.io/routerConfig: |
+      {
+        "domains": [ "deis" ],
+        "connectTimeout": 10,
+        "tcpTimeout": 1200
+      }
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  selector:
+    name: deis-workflow


### PR DESCRIPTION
This is one node Deis-Lite chart with persistent storage and it currently only works on kube-solo App
