### PR TITLE
Add healthchecks

### DIFF
--- a/deis-dev/manifests/deis-workflow-rc.yaml
+++ b/deis-dev/manifests/deis-workflow-rc.yaml
@@ -18,6 +18,12 @@ spec:
         - name: deis-workflow
           image: quay.io/deisci/workflow:v2-beta
           imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /health-check
+              port: 8000
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
           env:
             - name: DEIS_DATABASE_USER
               value: deis

--- a/deis-dev/manifests/deis-workflow-rc.yaml
+++ b/deis-dev/manifests/deis-workflow-rc.yaml
@@ -24,6 +24,12 @@ spec:
               port: 8000
             initialDelaySeconds: 30
             timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /health-check
+              port: 8000
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
           env:
             - name: DEIS_DATABASE_USER
               value: deis


### PR DESCRIPTION
Adds [liveness and readiness](http://kubernetes.io/v1.1/docs/user-guide/production-pods.html#liveness-and-readiness-probes-aka-health-checks) HTTP probes to the workflow RC manifest deis-dev beta chart.
