### PR TITLE
feat(registry): add k8s readiness and liveness probes

### DIFF
--- a/deis-dev/manifests/deis-registry-rc.yaml
+++ b/deis-dev/manifests/deis-registry-rc.yaml
@@ -18,6 +18,12 @@ spec:
         - name: deis-registry
           image: quay.io/deisci/registry:v2-beta
           imagePullPolicy: Always
+          readinessProbe:
+            httpGet:
+              path: /v2/
+              port: 5000
+            initialDelaySeconds: 1
+            timeoutSeconds: 1
           env:
             - name: REGISTRY_STORAGE_DELETE_ENABLED
               value: "true"

--- a/deis-dev/manifests/deis-registry-rc.yaml
+++ b/deis-dev/manifests/deis-registry-rc.yaml
@@ -18,6 +18,12 @@ spec:
         - name: deis-registry
           image: quay.io/deisci/registry:v2-beta
           imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /v2/
+              port: 5000
+            initialDelaySeconds: 1
+            timeoutSeconds: 1
           readinessProbe:
             httpGet:
               path: /v2/


### PR DESCRIPTION
Adds a k8s [readiness check](http://kubernetes.io/v1.1/docs/user-guide/production-pods.html#liveness-and-readiness-probes-aka-health-checks) and liveness check to the deis-registry ReplicationController manifest.
