### PR TITLE
feat(workflow): generate secrets for builder and django

### DIFF
--- a/deis-dev/manifests/deis-builder-rc.yaml
+++ b/deis-dev/manifests/deis-builder-rc.yaml
@@ -37,7 +37,13 @@ spec:
             - name: minio-user
               mountPath: /var/run/secrets/object/store
               readOnly: true
+            - name: builder-key-auth
+              mountPath: /var/run/secrets/api/auth
+              readOnly: true
       volumes:
         - name: minio-user
           secret:
             secretName: minio-user
+        - name: builder-key-auth
+          secret:
+            secretName: builder-key-auth

--- a/deis-dev/manifests/deis-workflow-rc.yaml
+++ b/deis-dev/manifests/deis-workflow-rc.yaml
@@ -44,6 +44,12 @@ spec:
             - name: minio-user
               mountPath: /var/run/secrets/deis/minio/user
               readOnly: true
+            - name: builder-key-auth
+              mountPath: /var/run/secrets/api/builder/auth
+              readOnly: true
+            - name: django-secret-key
+              mountPath: /var/run/secrets/api/django
+              readOnly: true
       volumes:
         - name: docker-socket
           hostPath:
@@ -51,3 +57,9 @@ spec:
         - name: minio-user
           secret:
             secretName: minio-user
+        - name: django-secret-key
+          secret:
+            secretName: django-secret-key
+        - name: builder-key-auth
+          secret:
+            secretName: builder-key-auth

--- a/deis-dev/tpl/deis-workflow-secret-builder-key-auth.yaml
+++ b/deis-dev/tpl/deis-workflow-secret-builder-key-auth.yaml
@@ -1,0 +1,11 @@
+#helm:generate helm tpl $HELM_GENERATE_DIR/tpl/deis-workflow-secret-builder-key-auth.yaml --out $HELM_GENERATE_DIR/manifests/deis-workflow-secret-builder-key-auth.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: builder-key-auth
+  namespace: deis
+  labels:
+    heritage: deis
+type: Opaque
+data:
+  builder-key: {{ randAscii 64 | b64enc }}

--- a/deis-dev/tpl/deis-workflow-secret-django-secret-key.yaml
+++ b/deis-dev/tpl/deis-workflow-secret-django-secret-key.yaml
@@ -1,0 +1,11 @@
+#helm:generate helm tpl $HELM_GENERATE_DIR/tpl/deis-workflow-secret-django-secret-key.yaml --out $HELM_GENERATE_DIR/manifests/deis-workflow-secret-django-secret-key.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: django-secret-key
+  namespace: deis
+  labels:
+    heritage: deis
+type: Opaque
+data:
+  secret-key: {{ randAscii 64 | b64enc }}


### PR DESCRIPTION
Requires helm `0.3` for template support
