### PR TITLE
feat(deis-minio-*): add and use persistent volumes in minio

### DIFF
--- a/deis-dev/manifests/deis-minio-pv.yaml
+++ b/deis-dev/manifests/deis-minio-pv.yaml
@@ -1,7 +1,7 @@
 kind: PersistentVolume
 apiVersion: v1
 metadata:
-  name: minio-data
+  name: deis-minio-data
   labels:
     type: local
 spec:

--- a/deis-dev/manifests/deis-minio-pv.yaml
+++ b/deis-dev/manifests/deis-minio-pv.yaml
@@ -1,0 +1,13 @@
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: minio-data
+  labels:
+    type: local
+spec:
+  capacity:
+    storage: 8Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: /mnt/minio/data

--- a/deis-dev/manifests/deis-minio-pvc.yaml
+++ b/deis-dev/manifests/deis-minio-pvc.yaml
@@ -1,7 +1,7 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: minio-data
+  name: deis-minio-data
   labels:
     type: local
 spec:

--- a/deis-dev/manifests/deis-minio-pvc.yaml
+++ b/deis-dev/manifests/deis-minio-pvc.yaml
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: minio-data
+  labels:
+    type: local
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 8Gi

--- a/deis-dev/manifests/deis-minio-rc.yaml
+++ b/deis-dev/manifests/deis-minio-rc.yaml
@@ -31,6 +31,8 @@ spec:
             - name: minio-user
               mountPath: /var/run/secrets/deis/minio/user
               readOnly: true
+            - name: minio-data
+              mountPath: /mnt/minio/data
       volumes:
         - name: minio-admin
           secret:
@@ -38,3 +40,6 @@ spec:
         - name: minio-user
           secret:
             secretName: minio-user
+        - name: minio-data
+          persistentVolumeClaim:
+            claimName: minio-data

--- a/deis-dev/manifests/deis-minio-rc.yaml
+++ b/deis-dev/manifests/deis-minio-rc.yaml
@@ -42,4 +42,4 @@ spec:
             secretName: minio-user
         - name: minio-data
           persistentVolumeClaim:
-            claimName: minio-data
+            claimName: deis-minio-data


### PR DESCRIPTION
This PR only enables persistence on the host's disk.

Volumes Reference: http://kubernetes.io/v1.1/docs/user-guide/volumes.html#persistentvolumeclaim
Persistence reference: https://github.com/kubernetes/kubernetes/blob/release-1.1/docs/user-guide/persistent-volumes.md

Only modifies `deis-dev` charts.

Related: https://github.com/deis/minio/pull/46
Ref: https://github.com/deis/deis/issues/4809
