### PR TITLE
feat(charts): Add canary charts

### DIFF
--- a/deis-canary/Chart.yaml
+++ b/deis-canary/Chart.yaml
@@ -1,0 +1,14 @@
+name: deis-dev
+home: https://github.com/deis/workflow
+version: v2-canary
+description: For testing only!
+maintainers:
+- Deis Team <engineering@deis.com>
+details: |-
+  WARNING: this chart is for testing only!  It tracks the latest builds of every
+  constituent component.  Features may not work, the components are not HA, and there are likely
+  to be bugs.
+
+  Deis (pronounced DAY-iss) is an open source PaaS that makes it easy to deploy
+  and manage applications on your own servers. Deis builds on Kubernetes
+  to provide a lightweight, Heroku-inspired workflow.

--- a/deis-canary/README.md
+++ b/deis-canary/README.md
@@ -1,0 +1,15 @@
+# Deis v2-canary
+
+WARNING: this chart is for testing only!  It tracks the latest builds of every constituent component.  Features may not work, the components are not HA, and there are likely to be bugs.
+
+Please report any issues you find in testing Deis v2 on Kubernetes
+to the appropriate GitHub repository:
+- builder: https://github.com/deis/builder
+- chart: https://github.com/deis/charts
+- database: https://github.com/deis/postgres
+- etcd: https://github.com/deis/etcd
+- helm: https://github.com/helm/helm
+- minio: https://github.com/deis/minio
+- registry: https://github.com/deis/registry
+- router: https://github.com/deis/router
+- workflow: https://github.com/deis/workflow

--- a/deis-canary/manifests/deis-builder-rc.yaml
+++ b/deis-canary/manifests/deis-builder-rc.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: deis-builder
+  namespace: deis
+  labels:
+    heritage: deis
+spec:
+  replicas: 1
+  selector:
+    app: deis-builder
+  template:
+    metadata:
+      labels:
+        app: deis-builder
+    spec:
+      containers:
+        - name: deis-builder
+          image: quay.io/deis/builder:canary
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 2223
+              name: ssh
+            - containerPort: 3000
+              name: fetcher
+          env:
+            - name: "EXTERNAL_PORT"
+              value: "2223"
+            # This var needs to be passed so that the minio client (https://github.com/minio/mc) will work in Alpine linux
+            - name: "DOCKERIMAGE"
+              value: "1"
+            - name: "POD_NAMESPACE"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: minio-user
+              mountPath: /var/run/secrets/object/store
+              readOnly: true
+            - name: builder-key-auth
+              mountPath: /var/run/secrets/api/auth
+              readOnly: true
+      volumes:
+        - name: minio-user
+          secret:
+            secretName: minio-user
+        - name: builder-key-auth
+          secret:
+            secretName: builder-key-auth

--- a/deis-canary/manifests/deis-builder-service.yaml
+++ b/deis-canary/manifests/deis-builder-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: deis-builder
+  namespace: deis
+  labels:
+    heritage: deis
+spec:
+  ports:
+    - name: ssh
+      port: 2222
+      targetPort: 2223
+  selector:
+    app: deis-builder

--- a/deis-canary/manifests/deis-database-rc.yaml
+++ b/deis-canary/manifests/deis-database-rc.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: deis-database
+  namespace: deis
+  labels:
+    heritage: deis
+spec:
+  replicas: 1
+  selector:
+    app: deis-database
+  template:
+    metadata:
+      labels:
+        app: deis-database
+    spec:
+      containers:
+        - name: deis-database
+          image: quay.io/deis/postgres:canary
+          imagePullPolicy: Always
+          env:
+            - name: POSTGRES_USER
+              value: "deis"
+            - name: POSTGRES_PASSWORD
+              value: "changeme123"
+          ports:
+            - containerPort: 5432

--- a/deis-canary/manifests/deis-database-service.yaml
+++ b/deis-canary/manifests/deis-database-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: deis-database
+  namespace: deis
+  labels:
+    heritage: deis
+spec:
+  ports:
+    - name: http
+      port: 5432
+  selector:
+    app: deis-database

--- a/deis-canary/manifests/deis-etcd-discovery-rc.yaml
+++ b/deis-canary/manifests/deis-etcd-discovery-rc.yaml
@@ -1,0 +1,46 @@
+kind: ReplicationController
+apiVersion: v1
+metadata:
+  name: deis-etcd-discovery
+  namespace: deis
+  labels:
+    name: deis-etcd-discovery
+    heritage: deis
+spec:
+  replicas: 1
+  selector:
+    app: deis-etcd-discovery
+  template:
+    metadata:
+      labels:
+        app: deis-etcd-discovery
+    spec:
+      volumes:
+        - name: discovery-token
+          secret:
+            secretName: deis-etcd-discovery-token
+      containers:
+        - name: deis-etcd-discovery
+          image: quay.io/deis/etcd:canary
+          imagePullPolicy: Always
+          command:
+            - /usr/local/bin/discovery
+          ports:
+            - containerPort: 2381
+          env:
+            - name: DEIS_ETCD_CLUSTER_SIZE
+              value: "3"
+            - name: ETCD_LISTEN_CLIENT_URLS
+              value: http://0.0.0.0:2381
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          volumeMounts:
+            - name: discovery-token
+              readOnly: true
+              mountPath: /var/run/secrets/deis/etcd/discovery

--- a/deis-canary/manifests/deis-etcd-discovery-service.yaml
+++ b/deis-canary/manifests/deis-etcd-discovery-service.yaml
@@ -1,0 +1,15 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: deis-etcd-discovery
+  namespace: deis
+  labels:
+    name: deis-etcd-discovery
+    app: deis
+    heritage: deis
+spec:
+  ports:
+    - name: client
+      port: 2381
+  selector:
+    app: deis-etcd-discovery

--- a/deis-canary/manifests/deis-etcd-discovery-token.yaml
+++ b/deis-canary/manifests/deis-etcd-discovery-token.yaml
@@ -1,0 +1,9 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: deis-etcd-discovery-token
+  namespace: deis
+  labels:
+    heritage: deis
+data:
+  token: "RTJENjQ1NzYtRDU0Ny00OThDLUFGNzEtM0NGNkVGMzE5QThCCg=="

--- a/deis-canary/manifests/deis-etcd-rc.yaml
+++ b/deis-canary/manifests/deis-etcd-rc.yaml
@@ -1,0 +1,42 @@
+kind: ReplicationController
+apiVersion: v1
+metadata:
+  name: deis-etcd-1
+  namespace: deis
+  labels:
+    name: deis-etcd-1
+    heritage: deis
+spec:
+  replicas: 3
+  selector:
+    app: deis-etcd-1
+  template:
+    metadata:
+      labels:
+        app: deis-etcd-1
+    spec:
+      volumes:
+        - name: discovery-token
+          secret:
+            secretName: deis-etcd-discovery-token
+      containers:
+        - name: deis-etcd-1
+          image: quay.io/deis/etcd:canary
+          imagePullPolicy: Always
+          env:
+            - name: DEIS_ETCD_CLUSTER_SIZE
+              value: "3"
+            - name: ETCD_NAME
+              value: deis1
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          volumeMounts:
+            - name: discovery-token
+              readOnly: true
+              mountPath: /var/run/secrets/deis/etcd/discovery

--- a/deis-canary/manifests/deis-etcd-service.yaml
+++ b/deis-canary/manifests/deis-etcd-service.yaml
@@ -1,0 +1,18 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: deis-etcd-1
+  namespace: deis
+  labels:
+    name: deis-etcd-1
+    app: deis
+    heritage: deis
+spec:
+  ports:
+    - name: peer
+      port: 2380
+      protocol: TCP
+    - name: client
+      port: 4100
+  selector:
+    app: deis-etcd-1

--- a/deis-canary/manifests/deis-minio-rc.yaml
+++ b/deis-canary/manifests/deis-minio-rc.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: deis-minio
+  namespace: deis
+  labels:
+    heritage: deis
+spec:
+  replicas: 1
+  selector:
+    app: deis-minio
+  template:
+    metadata:
+      labels:
+        app: deis-minio
+    spec:
+      containers:
+        - name: deis-minio
+          image: quay.io/deis/minio:canary
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 9000
+          command:
+            - boot
+          args:
+            - "server /home/minio/"
+          volumeMounts:
+            - name: minio-admin
+              mountPath: /var/run/secrets/deis/minio/admin
+              readOnly: true
+            - name: minio-user
+              mountPath: /var/run/secrets/deis/minio/user
+              readOnly: true
+      volumes:
+        - name: minio-admin
+          secret:
+            secretName: minio-admin
+        - name: minio-user
+          secret:
+            secretName: minio-user

--- a/deis-canary/manifests/deis-minio-secret-admin.yaml
+++ b/deis-canary/manifests/deis-minio-secret-admin.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-admin
+  namespace: deis
+  labels:
+    heritage: deis
+type: Opaque
+data:
+  access-key-id: YWRtaW4K
+  access-secret-key: cGRHOFJwdzBoOFF0eHliSHNNSGxrSnR6SnpaMnNDN2IyY0ZCRWduKwo=

--- a/deis-canary/manifests/deis-minio-secret-ssl.yaml
+++ b/deis-canary/manifests/deis-minio-secret-ssl.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-ssl
+  namespace: deis
+  labels:
+    heritage: deis
+type: Opaque
+data:
+  access-cert: OFRaUlkySlJXTVBUNlVNWFI2STUK
+  access-pem: Z2JzdHJPdm90TU1jZzJzTWZHVWhBNWE2RXQvRUk1QUx0SUhzb2JZawo=

--- a/deis-canary/manifests/deis-minio-secret-user.yaml
+++ b/deis-canary/manifests/deis-minio-secret-user.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-user
+  namespace: deis
+  labels:
+    heritage: deis
+type: Opaque
+data:
+  access-key-id: OFRaUlkySlJXTVBUNlVNWFI2STUK
+  access-secret-key: Z2JzdHJPdm90TU1jZzJzTWZHVWhBNWE2RXQvRUk1QUx0SUhzb2JZawo=

--- a/deis-canary/manifests/deis-minio-service.yaml
+++ b/deis-canary/manifests/deis-minio-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: deis-minio
+  namespace: deis
+  labels:
+    heritage: deis
+spec:
+  ports:
+    - name: s3
+      port: 9000
+  selector:
+    app: deis-minio

--- a/deis-canary/manifests/deis-namespace.yaml
+++ b/deis-canary/manifests/deis-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: deis
+  labels:
+    heritage: deis

--- a/deis-canary/manifests/deis-registry-rc.yaml
+++ b/deis-canary/manifests/deis-registry-rc.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: deis-registry
+  namespace: deis
+  labels:
+    heritage: deis
+spec:
+  replicas: 1
+  selector:
+    app: deis-registry
+  template:
+    metadata:
+      labels:
+        app: deis-registry
+    spec:
+      containers:
+        - name: deis-registry
+          image: quay.io/deis/registry:canary
+          imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /v2/
+              port: 5000
+            initialDelaySeconds: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /v2/
+              port: 5000
+            initialDelaySeconds: 1
+            timeoutSeconds: 1
+          env:
+            - name: REGISTRY_STORAGE_DELETE_ENABLED
+              value: "true"
+            - name: REGISTRY_LOG_LEVEL
+              value: info
+          ports:
+            - containerPort: 5000
+          volumeMounts:
+            - name: registry-storage
+              mountPath: /var/lib/registry
+      volumes:
+        - name: registry-storage
+          emptyDir: {}

--- a/deis-canary/manifests/deis-registry-service.yaml
+++ b/deis-canary/manifests/deis-registry-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: deis-registry
+  namespace: deis
+  labels:
+    heritage: deis
+spec:
+  ports:
+    - name: http
+      port: 5000
+  selector:
+    app: deis-registry

--- a/deis-canary/manifests/deis-router-rc.yaml
+++ b/deis-canary/manifests/deis-router-rc.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: deis-router
+  namespace: deis
+  labels:
+    heritage: deis
+  annotations:
+    router.deis.io/useProxyProtocol: "false"
+spec:
+  replicas: 1
+  selector:
+    app: deis-router
+  template:
+    metadata:
+      labels:
+        app: deis-router
+    spec:
+      serviceAccount: deis
+      containers:
+      - name: deis-router
+        image: quay.io/deis/router:canary
+        imagePullPolicy: Always
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        ports:
+        - containerPort: 80
+          hostPort: 80
+        - containerPort: 443
+          hostPort: 443
+        - containerPort: 2222
+          hostPort: 2222
+        - containerPort: 9090
+          hostPort: 9090
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9090
+          initialDelaySeconds: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 9090
+          initialDelaySeconds: 1
+          timeoutSeconds: 1

--- a/deis-canary/manifests/deis-router-service.yaml
+++ b/deis-canary/manifests/deis-router-service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: deis-router
+  namespace: deis
+  labels:
+    heritage: deis
+spec:
+  type: LoadBalancer
+  selector:
+    app: deis-router
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+    - name: https
+      port: 443
+      targetPort: 443
+    - name: builder
+      port: 2222
+      targetPort: 2222
+    - name: healthz
+      port: 9090
+      targetPort: 9090

--- a/deis-canary/manifests/deis-service-account.yaml
+++ b/deis-canary/manifests/deis-service-account.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: deis
+  namespace: deis
+  labels:
+    heritage: deis

--- a/deis-canary/manifests/deis-workflow-rc.yaml
+++ b/deis-canary/manifests/deis-workflow-rc.yaml
@@ -1,0 +1,65 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: deis-workflow
+  namespace: deis
+  labels:
+    heritage: deis
+spec:
+  replicas: 1
+  selector:
+    app: deis-workflow
+  template:
+    metadata:
+      labels:
+        app: deis-workflow
+    spec:
+      containers:
+        - name: deis-workflow
+          image: quay.io/deis/workflow:canary
+          imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /health-check
+              port: 8000
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /health-check
+              port: 8000
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+          env:
+            - name: DEIS_DATABASE_USER
+              value: deis
+            - name: DEIS_DATABASE_PASSWORD
+              value: changeme123
+          ports:
+            - containerPort: 8000
+              name: http
+          volumeMounts:
+            - mountPath: /var/run/docker.sock
+              name: docker-socket
+            - name: minio-user
+              mountPath: /var/run/secrets/deis/minio/user
+              readOnly: true
+            - name: builder-key-auth
+              mountPath: /var/run/secrets/api/builder/auth
+              readOnly: true
+            - name: django-secret-key
+              mountPath: /var/run/secrets/api/django
+              readOnly: true
+      volumes:
+        - name: docker-socket
+          hostPath:
+            path: /var/run/docker.sock
+        - name: minio-user
+          secret:
+            secretName: minio-user
+        - name: django-secret-key
+          secret:
+            secretName: django-secret-key
+        - name: builder-key-auth
+          secret:
+            secretName: builder-key-auth

--- a/deis-canary/manifests/deis-workflow-service.yaml
+++ b/deis-canary/manifests/deis-workflow-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: deis-workflow
+  namespace: deis
+  labels:
+    heritage: deis
+    routable: "true"
+  annotations:
+    router.deis.io/domains: deis
+    router.deis.io/connectTimeout: "10"
+    router.deis.io/tcpTimeout: "1200"
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  selector:
+    app: deis-workflow

--- a/deis-canary/tpl/deis-workflow-secret-builder-key-auth.yaml
+++ b/deis-canary/tpl/deis-workflow-secret-builder-key-auth.yaml
@@ -1,0 +1,11 @@
+#helm:generate helm tpl $HELM_GENERATE_DIR/tpl/deis-workflow-secret-builder-key-auth.yaml --out $HELM_GENERATE_DIR/manifests/deis-workflow-secret-builder-key-auth.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: builder-key-auth
+  namespace: deis
+  labels:
+    heritage: deis
+type: Opaque
+data:
+  builder-key: {{ randAscii 64 | b64enc }}

--- a/deis-canary/tpl/deis-workflow-secret-django-secret-key.yaml
+++ b/deis-canary/tpl/deis-workflow-secret-django-secret-key.yaml
@@ -1,0 +1,11 @@
+#helm:generate helm tpl $HELM_GENERATE_DIR/tpl/deis-workflow-secret-django-secret-key.yaml --out $HELM_GENERATE_DIR/manifests/deis-workflow-secret-django-secret-key.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: django-secret-key
+  namespace: deis
+  labels:
+    heritage: deis
+type: Opaque
+data:
+  secret-key: {{ randAscii 64 | b64enc }}

--- a/router-canary/Chart.yaml
+++ b/router-canary/Chart.yaml
@@ -1,0 +1,18 @@
+name: router
+home: https://github.com/deis/router
+version: v2-canary
+description: For testing only!
+maintainers:
+- Deis Team <engineering@deis.com>
+details: |-
+  WARNING: this chart is for testing only!  It tracks the latest build of the Deis Router. 
+  component.  Features may not work and there are likely to be bugs.
+
+  The Deis Router is a simple program that manages Nginx and Nginx configuration for managing
+  ingress to web applications in a Kubernetes cluster without requiring each to have their own
+  external (to the cluster) load balancer.  Router(s) will require a single external load balancer,
+  handle all ingress, and direct all incoming traffic to appropriate services within the cluster.  
+  
+  Router works by regularly querying the Kubernetes API for services labeled with `routable:
+  "true"`. Such services are compared to known services resident in memory. If there are
+  differences, new Nginx configuration is generated and Nginx is reloaded.

--- a/router-canary/README.md
+++ b/router-canary/README.md
@@ -1,0 +1,6 @@
+# Deis Router v2-canary
+
+WARNING: this chart is for testing only!  It tracks the latest build of the Deis Router component.
+Features may not work and there are likely to be bugs.
+
+Please report any issues to https://github.com/deis/router

--- a/router-canary/manifests/deis-router-rc.yaml
+++ b/router-canary/manifests/deis-router-rc.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: deis-router
+  namespace: deis
+  labels:
+    heritage: deis
+  annotations:
+    router.deis.io/useProxyProtocol: "false"
+spec:
+  replicas: 1
+  selector:
+    app: deis-router
+  template:
+    metadata:
+      labels:
+        app: deis-router
+    spec:
+      serviceAccount: deis
+      containers:
+      - name: deis-router
+        image: quay.io/deis/router:canary
+        imagePullPolicy: Always
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        ports:
+        - containerPort: 80
+          hostPort: 80
+        - containerPort: 443
+          hostPort: 443
+        - containerPort: 2222
+          hostPort: 2222
+        - containerPort: 9090
+          hostPort: 9090
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9090
+          initialDelaySeconds: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 9090
+          initialDelaySeconds: 1
+          timeoutSeconds: 1

--- a/router-canary/manifests/deis-router-service.yaml
+++ b/router-canary/manifests/deis-router-service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: deis-router
+  namespace: deis
+  labels:
+    heritage: deis
+spec:
+  type: LoadBalancer
+  selector:
+    app: deis-router
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+    - name: https
+      port: 443
+      targetPort: 443
+    - name: builder
+      port: 2222
+      targetPort: 2222
+    - name: healthz
+      port: 9090
+      targetPort: 9090

--- a/router-canary/manifests/deis-service-account.yaml
+++ b/router-canary/manifests/deis-service-account.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: deis
+  namespace: deis
+  labels:
+    heritage: deis


### PR DESCRIPTION
As soon at @jchauncey's PRs to each component to stop producing beta images on every build and start producing canary images instead gets merged, the `deis-dev` and `router-dev` charts in this repo are going to get really stale really fast because the images they reference won't be getting updated anymore.

This is a proactive countermeasure so that as soon as all those PRs are merged, we have charts available that are tracking the latest builds of all constituent components.

We can have a separate PR later to remove the `deis-dev` and `router-dev` charts once they are rendered useless.
