### PR TITLE
feat(deis-riakcs): add manifests to support RiakCS object storage (WIP)

### DIFF
--- a/deis-riakcs/deis-riak-bootstrap-pod.yaml
+++ b/deis-riakcs/deis-riak-bootstrap-pod.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: deis-riak-bootstrap
+  namespace: deis
+  labels:
+    name: riak
+    cluster_server: "true"
+    heritage: deis
+spec:
+  containers:
+    - name: riak
+      image: quay.io/deisci/riak:v2-beta
+      imagePullPolicy: Always
+      env:
+        - name:  RIAK_INET_DIST_MIN
+          value: "6001"
+        - name:  RIAK_INET_DIST_MAX
+          value: "6001"
+        - name:  RIAK_MASTER
+          value: "1"
+        - name: CLUSTER_SERVER_HTTP_PORT
+          value: "8080"
+      ports:
+        - containerPort: 4369
+        - containerPort: 6001
+        - containerPort: 8087
+        - containerPort: 8098
+        - containerPort: 8099
+        - containerPort: 8080


### PR DESCRIPTION
Very much a WIP. Our suite of Riak/RiakCS/related images aren't yet available. See http://docs.basho.com/riakcs/latest/ for product reference, and https://github.com/deis/riak for works in progress.
