### PR TITLE
feat(deis-tests): always pull updated test image

### DIFF
--- a/deis-tests/manifests/deis-tests-pod.yaml
+++ b/deis-tests/manifests/deis-tests-pod.yaml
@@ -9,6 +9,7 @@ spec:
   containers:
   - name: deis-e2e
     image: quay.io/deisci/deis-e2e:canary
+    imagePullPolicy: Always
     command: ["/bin/sh", "-c"]
     args: ["/bin/tests.test"]
   restartPolicy: Never


### PR DESCRIPTION
At least while the integration tests are changing often, always pulling a newer Docker test image if available is a more useful setting.
