### PR TITLE
feat(deis-ui): add deis-ui chart

### DIFF
--- a/deis-ui/Chart.yaml
+++ b/deis-ui/Chart.yaml
@@ -5,11 +5,12 @@ description: A graphical UI for Deis.
 maintainers:
 - Matthew Fisher <mfisher@deis.com>
 details: |-
-  Deis UI is a full client-side web application that interfaces with the Deis API. It is installed
-  into the deis namespace and communicates using the deis-worflow service. It also has certain
-  annotations to "hack" itself into Deis' router as an external application.
+  Deis UI is a third-party client-side web application that interfaces with the Deis API. It is
+  installed into the deis namespace and communicates using the deis-worflow service. It also has
+  certain annotations to "hack" itself into Deis' router as an external application.
 
   Ensure that you've installed either the deis or deis-dev charts before installing this chart,
   then go to www.$DEIS_DOMAIN in a browser to log into Deis.
 
-  Please report any issues or feature requests to https://github.com/jumbojett/deis-ui
+  Please note that this is not maintained by the Deis core development team and is missing many
+  features. Please report any issues and submit pull requests to https://github.com/jumbojett/deis-ui

--- a/deis-ui/Chart.yaml
+++ b/deis-ui/Chart.yaml
@@ -1,0 +1,15 @@
+name: deis-ui
+home: https://github.com/jumbojett/deis-ui
+version: 0.1.0
+description: A graphical UI for Deis.
+maintainers:
+- Matthew Fisher <mfisher@deis.com>
+details: |-
+  Deis UI is a full client-side web application that interfaces with the Deis API. It is installed
+  into the deis namespace and communicates using the deis-worflow service. It also has certain
+  annotations to "hack" itself into Deis' router as an external application.
+
+  Ensure that you've installed either the deis or deis-dev charts before installing this chart,
+  then go to www.$DEIS_DOMAIN in a browser to log into Deis.
+
+  Please report any issues or feature requests to https://github.com/jumbojett/deis-ui

--- a/deis-ui/README.md
+++ b/deis-ui/README.md
@@ -1,0 +1,10 @@
+# Deis UI
+
+Deis UI is a full client-side web application that interfaces with the Deis API. It is installed
+into the deis namespace and communicates using the deis-worflow service. It also has certain
+annotations to "hack" itself into Deis' router as an external application.
+
+Ensure that you've installed either the deis or deis-dev charts before installing this chart,
+then go to www.$DEIS_DOMAIN in a browser to log into Deis.
+
+Please report any issues to https://github.com/jumbojett/deis-ui

--- a/deis-ui/README.md
+++ b/deis-ui/README.md
@@ -1,10 +1,11 @@
 # Deis UI
 
-Deis UI is a full client-side web application that interfaces with the Deis API. It is installed
-into the deis namespace and communicates using the deis-worflow service. It also has certain
-annotations to "hack" itself into Deis' router as an external application.
+Deis UI is a third-party client-side web application that interfaces with the Deis API. It is
+installed into the deis namespace and communicates using the deis-worflow service. It also
+has certain annotations to "hack" itself into Deis' router as an external application.
 
 Ensure that you've installed either the deis or deis-dev charts before installing this chart,
 then go to www.$DEIS_DOMAIN in a browser to log into Deis.
 
-Please report any issues to https://github.com/jumbojett/deis-ui
+Please note that this is not maintained by the Deis core development team and is missing many
+features. Please report any issues and submit pull requests to https://github.com/jumbojett/deis-ui

--- a/deis-ui/manifests/deis-ui-rc.yaml
+++ b/deis-ui/manifests/deis-ui-rc.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: deis-ui
+  namespace: deis
+  labels:
+    heritage: deis
+spec:
+  replicas: 1
+  selector:
+    app: deis-ui
+  template:
+    metadata:
+      labels:
+        app: deis-ui
+    spec:
+      containers:
+      - name: deis-ui
+        image: quay.io/fishworks/deis-ui
+        imagePullPolicy: Always
+        env:
+        - name: DEIS_API
+          value: http://deis-workflow
+        ports:
+        - containerPort: 9000

--- a/deis-ui/manifests/deis-ui-service.yaml
+++ b/deis-ui/manifests/deis-ui-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: deis-ui
+  namespace: deis
+  labels:
+    heritage: deis
+    router.deis.io/routable: "true"
+  annotations:
+    router.deis.io/domains: www
+spec:
+  selector:
+    app: deis-ui
+  ports:
+    - name: http
+      port: 80
+      targetPort: 9000


### PR DESCRIPTION
See https://github.com/jumbojett/deis-ui

I've set up an automated job at https://quay.io/repository/fishworks/deis-ui which builds off pushes from https://github.com/fishworks/deis-ui on master. We'll have to eventually get @jumbojett's repository automatically deploying images from master so we don't need to rely on a third party (me) to keep my mirror up to date :)

To use:

```
$ helm install deis-dev
$ helm install deis-ui
```

Then hit www.$ROUTER_PUBLIC_IP.xip.io to view the web UI.
