### PR TITLE
fix(deis-dev/manifests/deis-minio-rc.yaml): add probes to the minio RC

### DIFF
--- a/deis-dev/manifests/deis-minio-rc.yaml
+++ b/deis-dev/manifests/deis-minio-rc.yaml
@@ -18,8 +18,24 @@ spec:
         - name: deis-minio
           image: quay.io/deisci/minio:v2-beta
           imagePullPolicy: Always
+          env:
+            - name: HEALTH_SERVER_PORT
+              value: "8082"
           ports:
             - containerPort: 9000
+            - containerPort: 8082
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8092
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8092
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
           command:
             - boot
           args:

--- a/deis-dev/manifests/deis-minio-rc.yaml
+++ b/deis-dev/manifests/deis-minio-rc.yaml
@@ -27,13 +27,13 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 8092
+              port: 8082
             initialDelaySeconds: 30
             timeoutSeconds: 1
           readinessProbe:
             httpGet:
               path: /healthz
-              port: 8092
+              port: 8082
             initialDelaySeconds: 30
             timeoutSeconds: 1
           command:


### PR DESCRIPTION
and configuration for the server inside the minio container that serves
the probes

Fixes #86 

Can check the box next to `Add health check` (under `Object Storage` > `minio deis/minio`) in https://github.com/deis/deis/issues/4809 when this is done.
