### PR TITLE
feat(deis-dev/manifests/deis-builder-rc.yaml): add liveness and readiness probes

### DIFF
--- a/deis-dev/manifests/deis-builder-rc.yaml
+++ b/deis-dev/manifests/deis-builder-rc.yaml
@@ -22,13 +22,8 @@ spec:
           ports:
             - containerPort: 2223
               name: ssh
-<<<<<<< 655039ce30e6cca6f422e0c270747851624b3ef6
-=======
-            - containerPort: 3000
-              name: fetcher
             - containerPort: 8092
               name: healthsrv
->>>>>>> feat(deis-dev/manifests/deis-builder-rc.yaml): add liveness and readiness probes
           env:
             - name: "HEALTH_SERVER_PORT"
               value: "8092"
@@ -47,13 +42,13 @@ spec:
             httpGet:
               path: /healthz
               port: 8092
-            initialDelaySeconds: 2
+            initialDelaySeconds: 30
             timeoutSeconds: 1
           readinessProbe:
             httpGet:
               path: /healthz
               port: 8092
-            initialDelaySeconds: 2
+            initialDelaySeconds: 30
             timeoutSeconds: 1
           volumeMounts:
             - name: minio-user

--- a/deis-dev/manifests/deis-builder-rc.yaml
+++ b/deis-dev/manifests/deis-builder-rc.yaml
@@ -47,13 +47,13 @@ spec:
             httpGet:
               path: /healthz
               port: 8092
-            initialDelaySeconds: 30
+            initialDelaySeconds: 2
             timeoutSeconds: 1
           readinessProbe:
             httpGet:
               path: /healthz
               port: 8092
-            initialDelaySeconds: 30
+            initialDelaySeconds: 2
             timeoutSeconds: 1
           volumeMounts:
             - name: minio-user

--- a/deis-dev/manifests/deis-builder-rc.yaml
+++ b/deis-dev/manifests/deis-builder-rc.yaml
@@ -22,7 +22,16 @@ spec:
           ports:
             - containerPort: 2223
               name: ssh
+<<<<<<< 655039ce30e6cca6f422e0c270747851624b3ef6
+=======
+            - containerPort: 3000
+              name: fetcher
+            - containerPort: 8092
+              name: healthsrv
+>>>>>>> feat(deis-dev/manifests/deis-builder-rc.yaml): add liveness and readiness probes
           env:
+            - name: "HEALTH_SERVER_PORT"
+              value: "8092"
             - name: "EXTERNAL_PORT"
               value: "2223"
             # This var needs to be passed so that the minio client (https://github.com/minio/mc) will work in Alpine linux
@@ -34,6 +43,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8092
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8092
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
           volumeMounts:
             - name: minio-user
               mountPath: /var/run/secrets/object/store


### PR DESCRIPTION
Fixes #87 
Requires deis/builder#149
Ref deis/deis#4809

When this is done, check the appropriate box on deis/deis#4809
