### PR TITLE
fix(router): Drop PROXY protocol option

### DIFF
--- a/deis-dev/manifests/deis-router-rc.yaml
+++ b/deis-dev/manifests/deis-router-rc.yaml
@@ -5,8 +5,6 @@ metadata:
   namespace: deis
   labels:
     heritage: deis
-  annotations:
-    router.deis.io/useProxyProtocol: "false"
 spec:
   replicas: 1
   selector:

--- a/router-dev/manifests/deis-router-rc.yaml
+++ b/router-dev/manifests/deis-router-rc.yaml
@@ -5,8 +5,6 @@ metadata:
   namespace: deis
   labels:
     heritage: deis
-  annotations:
-    router.deis.io/useProxyProtocol: "false"
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
After deis/router#116 is merged, these annotations for disabling PROXY protocol will be _wrong_ since the name of the annotation is changing to `router.deis.io/nginx.useProxyProtocol`.

Rather than fix it, removing these seems like a better option because `false` / disabled is the default value for this setting anyway.
