### PR TITLE
fix(deis-dev): hotfix chart syntax

### DIFF
--- a/deis-dev/manifests/deis-workflow-rc.yaml
+++ b/deis-dev/manifests/deis-workflow-rc.yaml
@@ -62,6 +62,6 @@ spec:
         - name: builder-key-auth
           secret:
             secretName: builder-key-auth
-        - name: database-creds:
+        - name: database-creds
           secret:
             secretName: database-creds

--- a/deis-dev/tpl/deis-database-secret-creds.yaml
+++ b/deis-dev/tpl/deis-database-secret-creds.yaml
@@ -1,0 +1,12 @@
+#helm:generate helm tpl $HELM_GENERATE_DIR/tpl/deis-database-secret-creds.yaml --out $HELM_GENERATE_DIR/manifests/deis-database-secret-creds.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: database-creds
+  namespace: deis
+  labels:
+    app: deis-database
+    heritage: deis
+data:
+  user: {{ randAscii 64 | b64enc }}
+  password: {{ randAscii 64 | b64enc }}

--- a/deis-dev/tpl/deis-database-secret.yaml
+++ b/deis-dev/tpl/deis-database-secret.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: database-creds
-  labels:
-    app: deis-database
-data:
-  user: {{ randAscii 64 | b64enc }}
-  password: {{ randAscii 64 | b64enc }}


### PR DESCRIPTION
The database secret was not getting templated properly because the helm generate
comment was missing and was not being installed into the deis
namespace. deis-workflow-rc.yaml also contained a typo.
