### PR TITLE
fix(deis-dev): do not use random ascii code for username/password

### DIFF
--- a/deis-dev/tpl/deis-database-secret-creds.yaml
+++ b/deis-dev/tpl/deis-database-secret-creds.yaml
@@ -8,5 +8,5 @@ metadata:
     app: deis-database
     heritage: deis
 data:
-  user: {{ randAscii 64 | b64enc }}
-  password: {{ randAscii 64 | b64enc }}
+  user: {{ "deis" | b64enc }}
+  password: {{ "changeme" | b64enc }}


### PR DESCRIPTION
postgres cannot handle random ascii characters as username/password. Reverting to old behaviour for now.
