### PR TITLE
chore(deis-dev): remove database envvars

### DIFF
--- a/deis-dev/manifests/deis-database-rc.yaml
+++ b/deis-dev/manifests/deis-database-rc.yaml
@@ -19,11 +19,6 @@ spec:
         - name: deis-database
           image: quay.io/deisci/postgres:v2-beta
           imagePullPolicy: Always
-          env:
-            - name: POSTGRES_USER
-              value: "deis"
-            - name: POSTGRES_PASSWORD
-              value: "changeme123"
           ports:
             - containerPort: 5432
           livenessProbe:


### PR DESCRIPTION
The username and password is now injected via secrets and as such is no longer used.
