### PR TITLE
fix(deis-dev): triple-single-quote JSON value for toml

### DIFF
--- a/deis-dev/tpl/objectstorage.toml
+++ b/deis-dev/tpl/objectstorage.toml
@@ -42,7 +42,5 @@ container = "your-container-name"
 [gcs]
 # key_json is expanded into a JSON file on the remote server. It must be
 # well-formatted JSON data.
-key_json = ```
-Paste JSON data here.
-```
+key_json = '''Paste JSON data here.'''
 bucket = "your-bucket-name"


### PR DESCRIPTION
Fixes this problem introduced by #123:

``` console
$ helm generate deis-dev
[ERROR] Error opening value file: Near line 45 (last key parsed 'gcs.key_json'): Expected value but found '`' instead.
[ERROR] Failed to complete generation: failed to execute helm template -o /Users/matt/.helm/workspace/charts/deis-dev/manifests/deis-registry-rc.yaml -d /Users/matt/.helm/workspace/charts/deis-dev/tpl/objectstorage.toml /Users/matt/.helm/workspace/charts/deis-dev/tpl/deis-registry-rc.yaml (/Users/matt/.helm/workspace/charts/deis-dev/tpl/deis-registry-rc.yaml): exit status 1
```

@kmala [had pointed out](https://github.com/deis/charts/pull/123#issuecomment-189072994) this change needed to be included.
