### PR TITLE
fix(deis-dev): change database liveness probe to readiness

### DIFF
--- a/deis-dev/tpl/deis-database-rc.yaml
+++ b/deis-dev/tpl/deis-database-rc.yaml
@@ -25,7 +25,7 @@ spec:
           env:
             - name: DATABASE_STORAGE
               value: {{default "minio" .storage}}
-          livenessProbe:
+          readinessProbe:
             exec:
               command:
                 - is_running


### PR DESCRIPTION
Sometimes, a wal-e restore can take longer than 30 seconds (such as
when restoring from S3). /bin/is_running will return that the
database is currently in recovery mode and is not ready to receive
connections, therefore kubernetes will kill the container. Since we
cannot give a good default, changing the probe to a readinessProbe
better reflects what is happening (database is down until the log
replays are finished).

See the conversation at https://github.com/deis/charts/pull/117#issuecomment-188902813
for the history on this approach.

ping @krancour as I know this specific issue was causing his pod to die when replaying WAL logs from S3.
