### PR TITLE
fix(deis-tests): use canary tag for image

### DIFF
--- a/deis-tests/manifests/deis-tests-pod.yaml
+++ b/deis-tests/manifests/deis-tests-pod.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
   - name: deis-e2e
-    image: quay.io/deisci/deis-e2e:git-c8e9ecd
+    image: quay.io/deisci/deis-e2e:canary
     imagePullPolicy: Always
     command: ["/bin/sh", "-c"]
     args: ["/bin/tests.test"]


### PR DESCRIPTION
Use workflow-e2e's docker _canary_ tag (most likely what everyone will want by default - the latest version of the tests).

Depends on deis/workflow-e2e#73
