### PR TITLE
fix(deis-dev): use minio as the default storage

### DIFF
--- a/deis-dev/tpl/deis-objectstorage-secret.yaml
+++ b/deis-dev/tpl/deis-objectstorage-secret.yaml
@@ -8,7 +8,9 @@ metadata:
   annotations:
     deis.io/objectstorage: "{{.storage}}"
 type: Opaque
-data: {{ if eq .storage "gcs" }}
+data: {{ if eq .storage "minio" }}
+  access-key-id: OFRaUlkySlJXTVBUNlVNWFI2STUK
+  access-secret-key: Z2JzdHJPdm90TU1jZzJzTWZHVWhBNWE2RXQvRUk1QUx0SUhzb2JZawo={{ else if eq .storage "gcs" }}
   key.json: {{ b64enc .gcs.key_json }}
   bucket: {{ b64enc .gcs.bucket }}{{ else if eq .storage "azure" }}
   accountname: {{ b64enc .azure.accountname }}

--- a/deis-dev/tpl/deis-registry-rc.yaml
+++ b/deis-dev/tpl/deis-registry-rc.yaml
@@ -38,7 +38,7 @@ spec:
             - name: REGISTRY_LOG_LEVEL
               value: info
             - name: REGISTRY_STORAGE
-              value: {{default "filesystem" .storage}}
+              value: {{default "minio" .storage}}
           ports:
             - containerPort: 5000
           volumeMounts:

--- a/deis-dev/tpl/objectstorage.toml
+++ b/deis-dev/tpl/objectstorage.toml
@@ -18,10 +18,7 @@
 # - azure: Store persistent data in Azure's object storage
 # - gcs: Store persistent data in Google Cloud Storage
 # - minio: Store persistent data on in-cluster Minio server
-storage = "filesystem"
-
-[filesystem]
-# This space intentionally left blank.
+storage = "minio"
 
 [minio]
 # This space intentionally left blank.


### PR DESCRIPTION
Use minio as the default storage backend. Add the accesskey and secret key of the minio to the object store secret so that we have one place where all the object store details are present. Once all the components use minio details from the object store we can delete the minio-user secret.
