### PR TITLE
feat(storage): add storage envs to builder and workflow rcs

### DIFF
--- a/deis-dev/manifests/deis-builder-rc.yaml
+++ b/deis-dev/manifests/deis-builder-rc.yaml
@@ -29,6 +29,8 @@ spec:
               value: "8092"
             - name: "EXTERNAL_PORT"
               value: "2223"
+            - name: BUILDER_STORAGE
+              value: {{default "minio" .storage}}
             # This var needs to be passed so that the minio client (https://github.com/minio/mc) will work in Alpine linux
             - name: "DOCKERIMAGE"
               value: "1"
@@ -57,6 +59,8 @@ spec:
             - name: builder-key-auth
               mountPath: /var/run/secrets/api/auth
               readOnly: true
+            - name: objectstore-creds
+              mountPath: /var/run/secrets/deis/objectstore/creds
       volumes:
         - name: minio-user
           secret:
@@ -64,3 +68,6 @@ spec:
         - name: builder-key-auth
           secret:
             secretName: builder-key-auth
+        - name: objectstore-creds
+          secret:
+            secretName: objectstorage-keyfile

--- a/deis-dev/manifests/deis-workflow-rc.yaml
+++ b/deis-dev/manifests/deis-workflow-rc.yaml
@@ -34,6 +34,9 @@ spec:
           ports:
             - containerPort: 8000
               name: http
+          env:
+            - name: "APP_STORAGE"
+              value: {{default "minio" .storage}}
           volumeMounts:
             - mountPath: /var/run/docker.sock
               name: docker-socket


### PR DESCRIPTION
builder and workflow will support unified deis-object store model.
Not mounting deis-object store secret to workflow. As workflow doesn;t actually talk to object store but creates a object store secret for an APP.
We have to make changes to workflow to read secret from API server and populate it back in app namespace 
