### PR TITLE
fix(logger): Add readiness and liveness probes

### DIFF
--- a/deis-logger/manifests/deis-logger-rc.yaml
+++ b/deis-logger/manifests/deis-logger-rc.yaml
@@ -25,3 +25,15 @@ spec:
         - containerPort: 1514
           name: transport
           protocol: UDP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8088
+          initialDelaySeconds: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8088
+          initialDelaySeconds: 1
+          timeoutSeconds: 1


### PR DESCRIPTION
Somehow the readiness and liveness probes were removed from the logger rc. This pr adds them back
