### PR TITLE
fix(deis-logger/manifests/deis-logger-svc.yaml): make the logger service run on port 80

### DIFF
--- a/deis-logger/manifests/deis-logger-svc.yaml
+++ b/deis-logger/manifests/deis-logger-svc.yaml
@@ -9,7 +9,6 @@ metadata:
 spec:
   ports:
   - port: 80
-    targetPort: 8088
     name: http
     targetPort: http
   - port: 514

--- a/deis-logger/manifests/deis-logger-svc.yaml
+++ b/deis-logger/manifests/deis-logger-svc.yaml
@@ -8,7 +8,8 @@ metadata:
     app: deis-logger
 spec:
   ports:
-  - port: 8088
+  - port: 80
+    targetPort: 8088
     name: http
     targetPort: http
   - port: 514


### PR DESCRIPTION
Fixes #136
Ref deis/deis#4853

cc/ @jchauncey 
