### PR TITLE
fix(deis-dev/manifests/deis-minio-service.yaml): make the minio service listen on port 80

### DIFF
--- a/deis-dev/manifests/deis-minio-service.yaml
+++ b/deis-dev/manifests/deis-minio-service.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   ports:
     - name: s3
-      port: 9000
+      port: 80
+      targetPort: 9000
   selector:
     app: deis-minio


### PR DESCRIPTION
Fixes #138
Ref deis/deis#4853

cc/ @smothiki @kmala
