### PR TITLE
fix(deis-dev/manifests/deis-registry-service.yaml): make the registry service listen on port 80

### DIFF
--- a/deis-dev/manifests/deis-registry-service.yaml
+++ b/deis-dev/manifests/deis-registry-service.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   ports:
     - name: http
-      port: 5000
+      port: 80
+      targetPort: 5000
   selector:
     app: deis-registry


### PR DESCRIPTION
Fixes #139
Ref deis/deis#4853
