### PR TITLE
fix(deis-dev/tpl/deis-builder-rc.yaml): make the objectstore-creds secret read-only

### DIFF
--- a/workflow-beta1/tpl/deis-builder-rc.yaml
+++ b/workflow-beta1/tpl/deis-builder-rc.yaml
@@ -70,6 +70,7 @@ spec:
               readOnly: true
             - name: objectstore-creds
               mountPath: /var/run/secrets/deis/objectstore/creds
+              readOnly: true
       volumes:
         - name: minio-user
           secret:

--- a/workflow-beta1/tpl/deis-builder-rc.yaml
+++ b/workflow-beta1/tpl/deis-builder-rc.yaml
@@ -70,7 +70,6 @@ spec:
               readOnly: true
             - name: objectstore-creds
               mountPath: /var/run/secrets/deis/objectstore/creds
-              readOnly: true
       volumes:
         - name: minio-user
           secret:

--- a/workflow-dev/tpl/deis-builder-rc.yaml
+++ b/workflow-dev/tpl/deis-builder-rc.yaml
@@ -71,6 +71,7 @@ spec:
               readOnly: true
             - name: objectstore-creds
               mountPath: /var/run/secrets/deis/objectstore/creds
+              readonly: true
       volumes:
         - name: builder-key-auth
           secret:

--- a/workflow-dev/tpl/deis-builder-rc.yaml
+++ b/workflow-dev/tpl/deis-builder-rc.yaml
@@ -71,7 +71,7 @@ spec:
               readOnly: true
             - name: objectstore-creds
               mountPath: /var/run/secrets/deis/objectstore/creds
-              readonly: true
+              readOnly: true
       volumes:
         - name: builder-key-auth
           secret:


### PR DESCRIPTION
As far as I know, builder does not write to this volume, nor should it.

@smothiki thoughts?
