### PR TITLE
chore(deis-tests): sync command-line e2e options

### DIFF
--- a/deis-tests/manifests/deis-tests-pod.yaml
+++ b/deis-tests/manifests/deis-tests-pod.yaml
@@ -10,6 +10,6 @@ spec:
   - name: deis-e2e
     image: quay.io/deisci/deis-e2e:canary
     imagePullPolicy: Always
-    command: ["/bin/sh", "-c"]
-    args: ["/bin/tests.test"]
+    command: ["/bin/tests.test"]
+    args: ["-test.v", "-test.timeout=60m", "-ginkgo.v", "-ginkgo.slowSpecThreshold=120"]
   restartPolicy: Never


### PR DESCRIPTION
Closes deis/workflow-e2e#97.

See deis/workflow-e2e#99.
