### PR TITLE
fix(quay): now with a working image!

### DIFF
--- a/deis-dev/manifests/deis-workflow-manager-rc.yaml
+++ b/deis-dev/manifests/deis-workflow-manager-rc.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccount: deis-workflow-manager
       containers:
       - name: deis-workflow-manager
-        image: quay.io/deisci/workflow-manager:git-941cb10
+        image: quay.io/deisci/workflow-manager:git-d04aeb9
         imagePullPolicy: Always
         env:
         - name: POD_NAMESPACE


### PR DESCRIPTION
To test this image, you should see a +x'd file at:

`docker run --rm quay.io/deisci/workflow-manager:git-d04aeb9 ls -al /bin/boot`
