### PR TITLE
fix(deis-dev): use canary instead of v2-beta where it makes sense

### DIFF
--- a/deis-dev/tpl/deis-builder-rc.yaml
+++ b/deis-dev/tpl/deis-builder-rc.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccount: deis-builder
       containers:
         - name: deis-builder
-          image: quay.io/deisci/builder:v2-beta
+          image: quay.io/deisci/builder:canary
           imagePullPolicy: Always
           ports:
             - containerPort: 2223

--- a/deis-dev/tpl/deis-controller-rc.yaml
+++ b/deis-dev/tpl/deis-controller-rc.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccount: deis-controller
       containers:
         - name: deis-controller
-          image: quay.io/deisci/controller:git-a9faeab
+          image: quay.io/deisci/controller:canary
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:


### PR DESCRIPTION
Main reason for this change is the move from pushing v2-beta tags to canary + immutable tags... I've only applied those changes to builder and workflow now. I'm looking to see some e2e green, and this is the best way to ensure we're grabbing the latest version of those two components.
