### PR TITLE
bug(postgres): use an explicit volume for postgres

### DIFF
--- a/deis-dev/tpl/deis-database-rc.yaml
+++ b/deis-dev/tpl/deis-database-rc.yaml
@@ -38,6 +38,8 @@ spec:
               mountPath: /var/run/secrets/deis/database/creds
             - name: objectstore-creds
               mountPath: /var/run/secrets/deis/objectstore/creds
+            - name: postgres-data
+              mountPath: /var/lib/postgresql
       volumes:
         - name: minio-user
           secret:
@@ -48,3 +50,5 @@ spec:
         - name: objectstore-creds
           secret:
             secretName: objectstorage-keyfile
+        - name: postgres-data
+          emptyDir: {}


### PR DESCRIPTION
Use a concrete volume declaration for the postgres component.

Haven't found the concrete root cause yet, but this seems to address
deis/postgres#63

Update: fixes deis/postgres#63
