### PR TITLE
Revert "bug(postgres): use an explicit volume for postgres"

### DIFF
--- a/deis-dev/tpl/deis-database-rc.yaml
+++ b/deis-dev/tpl/deis-database-rc.yaml
@@ -38,8 +38,6 @@ spec:
               mountPath: /var/run/secrets/deis/database/creds
             - name: objectstore-creds
               mountPath: /var/run/secrets/deis/objectstore/creds
-            - name: postgres-data
-              mountPath: /var/lib/postgresql
       volumes:
         - name: minio-user
           secret:
@@ -50,5 +48,3 @@ spec:
         - name: objectstore-creds
           secret:
             secretName: objectstorage-keyfile
-        - name: postgres-data
-          emptyDir: {}


### PR DESCRIPTION
reverts deis/charts#160 and unblocks CI. While it bypasses deis/postgres#63, this introduced more issues since the database was not designed to be backed by a persistent disk.
