### PR TITLE
feat(deis-tests): mount /tmp emptyDir for storing artifacts

### DIFF
--- a/deis-tests/manifests/deis-tests-pod.yaml
+++ b/deis-tests/manifests/deis-tests-pod.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     heritage: deis
 spec:
+  restartPolicy: Never
   containers:
   - name: deis-e2e
     image: quay.io/deisci/deis-e2e:canary
@@ -15,4 +16,16 @@ spec:
     env:
       - name: JUNIT
         value: "true"
-  restartPolicy: Never
+    volumeMounts:
+    - name: artifact-volume
+      mountPath: /root
+  - name: artifacts
+    image: busybox
+    imagePullPolicy: Always
+    command: ["tail", "-f", "/dev/null"]
+    volumeMounts:
+    - name: artifact-volume
+      mountPath: /root
+  volumes:
+  - name: artifact-volume
+    emptyDir: {}


### PR DESCRIPTION
Allows us to store build artifacts in the sidecar container for future processing after the tests have finished running. I decided on `/root` because that is the home directory when running the tests.

Example:

```
><> kd exec -c deis-e2e deis-tests -- sh -c 'echo "hello" > /root/foo'
><> kd exec -c artifacts deis-tests -- cat /root/foo
hello
```

BREAKING CHANGES:

with `kubectl --namespace=deis logs`, you now have to specify the container name with `-c`. Because of this, changes to sgoings/chart-mate also need to occur so that it will continue to work with this change.

History and motivation behind this change is for https://github.com/sgoings/chart-mate/pull/28
