### PR TITLE
feat(settings): use k8s 1.2 secrets as env vars to configure production settings

### DIFF
--- a/workflow-dev/tpl/deis-builder-rc.yaml
+++ b/workflow-dev/tpl/deis-builder-rc.yaml
@@ -45,6 +45,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: DEIS_BUILDER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: builder-key-auth
+                  key: builder-key
           livenessProbe:
             httpGet:
               path: /healthz

--- a/workflow-dev/tpl/deis-controller-rc.yaml
+++ b/workflow-dev/tpl/deis-controller-rc.yaml
@@ -40,6 +40,26 @@ spec:
               value: {{default "minio" .storage}}
             - name: "SLUGRUNNER_IMAGE_NAME"
               value: "quay.io/deisci/slugrunner:canary"
+            - name: DEIS_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: django-secret-key
+                  key: secret-key
+            - name: DEIS_BUILDER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: builder-key-auth
+                  key: builder-key
+            - name: DEIS_DATABASE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: database-creds
+                  key: user
+            - name: DEIS_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: database-creds
+                  key: password
           volumeMounts:
             - mountPath: /var/run/docker.sock
               name: docker-socket


### PR DESCRIPTION
Keeping the mount points for now since they do not harm anything

http://kubernetes.io/docs/user-guide/secrets/#using-secrets-as-environment-variables
