### PR TITLE
feature(deis-tests): Add a chart that runs the workflow-e2e tests in parallel

### DIFF
--- a/deis-tests-parallel/Chart.yaml
+++ b/deis-tests-parallel/Chart.yaml
@@ -1,0 +1,12 @@
+name: deis-tests-parallel
+home: https://github.com/deis/workflow-e2e
+version: v2-beta
+description: End-to-end tests for Deis v2 which are run in parallel
+maintainers:
+- Deis Team <engineering@deis.com>
+details: |-
+  Runs the End-to-end (e2e) workflow tests for the Deis v2 open source PaaS in parallel.
+
+  Deis (pronounced DAY-iss) is an open source PaaS that makes it easy to deploy
+  and manage applications on your own servers. Deis builds on Kubernetes
+  to provide a lightweight, Heroku-inspired workflow.

--- a/deis-tests-parallel/README.md
+++ b/deis-tests-parallel/README.md
@@ -1,0 +1,12 @@
+# Deis 2.0.0-beta Tests parallel
+
+End-to-end tests for the Deis v2 open source PaaS.
+
+NOTE: This assumes a fresh `helm install` of Deis v2. The test suite creates
+an initial user with admin privileges (who is deleted when tests complete).
+See https://github.com/deis/workflow-e2e for more detail.
+
+```console
+$ helm uninstall -n deis -y deis-tests ; helm install deis-tests
+$ kubectl --namespace=deis logs -f deis-tests
+```

--- a/deis-tests-parallel/manifests/deis-tests-parallel-pod.yaml
+++ b/deis-tests-parallel/manifests/deis-tests-parallel-pod.yaml
@@ -12,14 +12,10 @@ spec:
     image: quay.io/deisci/deis-e2e:canary
     imagePullPolicy: Always
     command: ["ginkgo"]
-    args: ["-slowSpecThreshold=120.00", "-noisyPendings=false", "-progress", "tests/"]
+    args: ["-slowSpecThreshold=120.00", "-nodes=30", "-noisyPendings=false", "-progress", "tests/"]
     env:
       - name: JUNIT
         value: "true"
-      - name: DEFAULT_MAX_TIMEOUT
-        value: "300s"
-      - name: DEFAULT_EVENTUALLY_TIMEOUT
-        value: "30s"
     volumeMounts:
     - name: artifact-volume
       mountPath: /root


### PR DESCRIPTION
This PR also changes how we launch the sequential workflow-e2e tests

this pr is required for https://github.com/deis/workflow-e2e/pull/135
