### PR TITLE
ref(workflow-e2e): Use default command specified by image

### DIFF
--- a/workflow-beta1-e2e/manifests/deis-tests-pod.yaml
+++ b/workflow-beta1-e2e/manifests/deis-tests-pod.yaml
@@ -11,11 +11,6 @@ spec:
   - name: deis-e2e
     image: quay.io/deis/deis-e2e:v2.0.0-beta1
     imagePullPolicy: IfNotPresent
-    command: ["/bin/tests.test"]
-    args: ["-test.v", "-test.timeout=60m", "-ginkgo.v", "-ginkgo.slowSpecThreshold=120"]
-    env:
-      - name: JUNIT
-        value: "true"
     volumeMounts:
     - name: artifact-volume
       mountPath: /root


### PR DESCRIPTION
This change complements https://github.com/deis/workflow-e2e/pull/157

The idea here is that the e2e test image itself will specify the default command used to kick off the tests.  This consolidates responsibility for _how_ the tests are executed into the deis/workflow-e2e repo and reduces the need for future changes to this chart if / as _how_ we execute tests changes.

At the same time, I've eliminated setting the `JUNIT` env var since that is defaulted to true in the image.

cc @vdice
