### PR TITLE
feat(storage): remove the minio user secret

### DIFF
--- a/workflow-dev/tpl/deis-database-rc.yaml
+++ b/workflow-dev/tpl/deis-database-rc.yaml
@@ -32,16 +32,11 @@ spec:
             initialDelaySeconds: 30
             timeoutSeconds: 1
           volumeMounts:
-            - name: minio-user
-              mountPath: /etc/wal-e.d/env
             - name: database-creds
               mountPath: /var/run/secrets/deis/database/creds
             - name: objectstore-creds
               mountPath: /var/run/secrets/deis/objectstore/creds
       volumes:
-        - name: minio-user
-          secret:
-            secretName: minio-user
         - name: database-creds
           secret:
             secretName: database-creds


### PR DESCRIPTION
We are no longer using the minio user secret and instead using the objectstorage-keyfile secret.
