### PR TITLE
chore: Allows for specifying the docker tag of a component image as an environment variable

### DIFF
--- a/workflow-dev-e2e/tpl/workflow-e2e-pod.yaml
+++ b/workflow-dev-e2e/tpl/workflow-e2e-pod.yaml
@@ -10,7 +10,7 @@ spec:
   restartPolicy: Never
   containers:
   - name: tests
-    image: quay.io/{{.e2e.org}}/workflow-e2e:{{.e2e.dockerTag}}
+    image: quay.io/{{.e2e.org}}/workflow-e2e:{{env WORKFLOW_E2E_GIT_TAG | default .e2e.dockerTag}}
     imagePullPolicy: {{.e2e.pullPolicy}}
     env:
       - name: GINKGO_NODES

--- a/workflow-dev/tpl/deis-builder-rc.yaml
+++ b/workflow-dev/tpl/deis-builder-rc.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccount: deis-builder
       containers:
         - name: deis-builder
-          image: quay.io/{{.builder.org}}/builder:{{.builder.dockerTag}}
+          image: quay.io/{{.builder.org}}/builder:{{ env "BUILDER_GIT_TAG" | default .builder.dockerTag}}
           imagePullPolicy: {{.builder.pullPolicy}}
           ports:
             - containerPort: 2223
@@ -33,9 +33,9 @@ spec:
             - name: BUILDER_STORAGE
               value: {{default "minio" .storage}}
             - name: "SLUGBUILDER_IMAGE_NAME"
-              value: "quay.io/deisci/slugbuilder:git-a713e13"
+              value: "quay.io/{{.slugbuilder.org}}/slugbuilder:{{ env "SLUGBUILDER_GIT_TAG" | default .slugbuilder.dockerTag }}"
             - name: "DOCKERBUILDER_IMAGE_NAME"
-              value: "quay.io/deisci/dockerbuilder:canary"
+              value: "quay.io/{{.dockerbuilder.org}}/dockerbuilder:{{ env "DOCKERBUILDER_GIT_TAG" | default .dockerbuilder.dockerTag}}"
             # This var needs to be passed so that the minio client (https://github.com/minio/mc) will work in Alpine linux
             - name: "DOCKERIMAGE"
               value: "1"

--- a/workflow-dev/tpl/deis-controller-rc.yaml
+++ b/workflow-dev/tpl/deis-controller-rc.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccount: deis-controller
       containers:
         - name: deis-controller
-          image: quay.io/{{.controller.org}}/controller:{{.controller.dockerTag}}
+          image: quay.io/{{.controller.org}}/controller:{{env "CONTROLLER_GIT_TAG" | default .controller.dockerTag}}
           imagePullPolicy: {{.controller.pullPolicy}}
           livenessProbe:
             httpGet:
@@ -39,7 +39,7 @@ spec:
             - name: "APP_STORAGE"
               value: {{default "minio" .storage}}
             - name: "SLUGRUNNER_IMAGE_NAME"
-              value: "quay.io/deisci/slugrunner:canary"
+              value: "quay.io/{{.slugrunner.org}}/slugrunner:{{env "SLUGRUNNER_GIT_TAG" | default .slugrunner.dockerTag}}"
             - name: DEIS_SECRET_KEY
               valueFrom:
                 secretKeyRef:

--- a/workflow-dev/tpl/deis-database-rc.yaml
+++ b/workflow-dev/tpl/deis-database-rc.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccount: deis-database
       containers:
         - name: deis-database
-          image: quay.io/{{.database.org}}/postgres:{{.database.dockerTag}}
+          image: quay.io/{{.database.org}}/postgres:{{env "DATABASE_GIT_TAG" | default .database.dockerTag}}
           imagePullPolicy: {{.database.pullPolicy}}
           ports:
             - containerPort: 5432

--- a/workflow-dev/tpl/deis-logger-fluentd-daemon.yaml
+++ b/workflow-dev/tpl/deis-logger-fluentd-daemon.yaml
@@ -1,3 +1,4 @@
+#helm:generate helm tpl -d $HELM_GENERATE_DIR/tpl/generate_params.toml -o $HELM_GENERATE_DIR/manifests/deis-logger-fluentd-daemon.yaml $HELM_GENERATE_FILE
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -20,8 +21,8 @@ spec:
       serviceAccount: deis-logger-fluentd
       containers:
       - name: deis-logger-fluentd
-        image: quay.io/deisci/fluentd:canary
-        imagePullPolicy: Always
+        image: quay.io/{{ .fluentd.org }}/fluentd:{{env "FLUENTD_GIT_TAG" | default .fluentd.dockerTag}}
+        imagePullPolicy: {{.fluentd.pullPolicy}}
         securityContext:
           privileged: true
         volumeMounts:

--- a/workflow-dev/tpl/deis-logger-rc.yaml
+++ b/workflow-dev/tpl/deis-logger-rc.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: deis-logger
-        image: quay.io/{{.logger.org}}/logger:{{.logger.dockerTag}}
+        image: quay.io/{{.logger.org}}/logger:{{env "LOGGER_GIT_TAG" | default .logger.dockerTag}}
         imagePullPolicy: {{.logger.pullPolicy}}
         ports:
         - containerPort: 8088

--- a/workflow-dev/tpl/deis-minio-rc.yaml
+++ b/workflow-dev/tpl/deis-minio-rc.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccount: deis-minio
       containers:
         - name: deis-minio
-          image: quay.io/{{.minio.org}}/minio:{{.minio.dockerTag}}
+          image: quay.io/{{.minio.org}}/minio:{{env "MINIO_GIT_TAG" | default .minio.dockerTag}}
           imagePullPolicy: {{.minio.pullPolicy}}
           env:
             - name: HEALTH_SERVER_PORT

--- a/workflow-dev/tpl/deis-registry-rc.yaml
+++ b/workflow-dev/tpl/deis-registry-rc.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccount: deis-registry
       containers:
         - name: deis-registry
-          image: quay.io/{{.registry.org}}/registry:{{.registry.dockerTag}}
+          image: quay.io/{{.registry.org}}/registry:{{env "REGISTRY_GIT_TAG" | default .registry.dockerTag}}
           imagePullPolicy: {{.registry.pullPolicy}}
           livenessProbe:
             httpGet:

--- a/workflow-dev/tpl/deis-router-rc.yaml
+++ b/workflow-dev/tpl/deis-router-rc.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccount: deis-router
       containers:
       - name: deis-router
-        image: quay.io/{{.router.org}}/router:{{.router.dockerTag}}
+        image: quay.io/{{.router.org}}/router:{{env "ROUTER_GIT_TAG" | default .router.dockerTag}}
         imagePullPolicy: {{.router.pullPolicy}}
         env:
         - name: POD_NAMESPACE

--- a/workflow-dev/tpl/deis-workflow-manager-rc.yaml
+++ b/workflow-dev/tpl/deis-workflow-manager-rc.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccount: deis-workflow-manager
       containers:
       - name: deis-workflow-manager
-        image: quay.io/{{.workflowManager.org}}/workflow-manager:{{.workflowManager.dockerTag}}
+        image: quay.io/{{.workflowManager.org}}/workflow-manager:{{env "WORKFLOW_MANAGER_GIT_TAG" | default .workflowManager.dockerTag}}
         imagePullPolicy: {{.workflowManager.pullPolicy}}
         env:
         - name: POD_NAMESPACE


### PR DESCRIPTION
This changes only the workflow-dev and workflow-dev-e2e charts for now.
