### PR TITLE
fix(workflow-dev): fixup incorrect usage of helm tpl

### DIFF
--- a/workflow-beta1/tpl/deis-controller-secret-builder-key-auth.yaml
+++ b/workflow-beta1/tpl/deis-controller-secret-builder-key-auth.yaml
@@ -1,4 +1,4 @@
-#helm:generate helm tpl $HELM_GENERATE_DIR/tpl/deis-controller-secret-builder-key-auth.yaml --out $HELM_GENERATE_DIR/manifests/deis-controller-secret-builder-key-auth.yaml
+#helm:generate helm tpl --out $HELM_GENERATE_DIR/manifests/deis-controller-secret-builder-key-auth.yaml $HELM_GENERATE_DIR/tpl/deis-controller-secret-builder-key-auth.yaml
 apiVersion: v1
 kind: Secret
 metadata:

--- a/workflow-beta1/tpl/deis-controller-secret-django-secret-key.yaml
+++ b/workflow-beta1/tpl/deis-controller-secret-django-secret-key.yaml
@@ -1,4 +1,4 @@
-#helm:generate helm tpl $HELM_GENERATE_DIR/tpl/deis-controller-secret-django-secret-key.yaml --out $HELM_GENERATE_DIR/manifests/deis-controller-secret-django-secret-key.yaml
+#helm:generate helm tpl --out $HELM_GENERATE_DIR/manifests/deis-controller-secret-django-secret-key.yaml $HELM_GENERATE_DIR/tpl/deis-controller-secret-django-secret-key.yaml
 apiVersion: v1
 kind: Secret
 metadata:

--- a/workflow-beta1/tpl/deis-database-secret-creds.yaml
+++ b/workflow-beta1/tpl/deis-database-secret-creds.yaml
@@ -1,4 +1,4 @@
-#helm:generate helm tpl $HELM_GENERATE_DIR/tpl/deis-database-secret-creds.yaml --out $HELM_GENERATE_DIR/manifests/deis-database-secret-creds.yaml
+#helm:generate helm tpl --out $HELM_GENERATE_DIR/manifests/deis-database-secret-creds.yaml $HELM_GENERATE_DIR/tpl/deis-database-secret-creds.yaml
 apiVersion: v1
 kind: Secret
 metadata:

--- a/workflow-beta2/tpl/deis-controller-secret-builder-key-auth.yaml
+++ b/workflow-beta2/tpl/deis-controller-secret-builder-key-auth.yaml
@@ -1,4 +1,4 @@
-#helm:generate helm tpl $HELM_GENERATE_DIR/tpl/deis-controller-secret-builder-key-auth.yaml --out $HELM_GENERATE_DIR/manifests/deis-controller-secret-builder-key-auth.yaml
+#helm:generate helm tpl --out $HELM_GENERATE_DIR/manifests/deis-controller-secret-builder-key-auth.yaml $HELM_GENERATE_DIR/tpl/deis-controller-secret-builder-key-auth.yaml
 apiVersion: v1
 kind: Secret
 metadata:

--- a/workflow-beta2/tpl/deis-controller-secret-django-secret-key.yaml
+++ b/workflow-beta2/tpl/deis-controller-secret-django-secret-key.yaml
@@ -1,4 +1,4 @@
-#helm:generate helm tpl $HELM_GENERATE_DIR/tpl/deis-controller-secret-django-secret-key.yaml --out $HELM_GENERATE_DIR/manifests/deis-controller-secret-django-secret-key.yaml
+#helm:generate helm tpl --out $HELM_GENERATE_DIR/manifests/deis-controller-secret-django-secret-key.yaml $HELM_GENERATE_DIR/tpl/deis-controller-secret-django-secret-key.yaml
 apiVersion: v1
 kind: Secret
 metadata:

--- a/workflow-beta2/tpl/deis-database-secret-creds.yaml
+++ b/workflow-beta2/tpl/deis-database-secret-creds.yaml
@@ -1,4 +1,4 @@
-#helm:generate helm tpl $HELM_GENERATE_DIR/tpl/deis-database-secret-creds.yaml --out $HELM_GENERATE_DIR/manifests/deis-database-secret-creds.yaml
+#helm:generate helm tpl --out $HELM_GENERATE_DIR/manifests/deis-database-secret-creds.yaml $HELM_GENERATE_DIR/tpl/deis-database-secret-creds.yaml
 apiVersion: v1
 kind: Secret
 metadata:

--- a/workflow-dev/tpl/deis-controller-secret-builder-key-auth.yaml
+++ b/workflow-dev/tpl/deis-controller-secret-builder-key-auth.yaml
@@ -1,4 +1,4 @@
-#helm:generate helm tpl $HELM_GENERATE_DIR/tpl/deis-controller-secret-builder-key-auth.yaml --out $HELM_GENERATE_DIR/manifests/deis-controller-secret-builder-key-auth.yaml
+#helm:generate helm tpl --out $HELM_GENERATE_DIR/manifests/deis-controller-secret-builder-key-auth.yaml $HELM_GENERATE_DIR/tpl/deis-controller-secret-builder-key-auth.yaml
 apiVersion: v1
 kind: Secret
 metadata:

--- a/workflow-dev/tpl/deis-controller-secret-django-secret-key.yaml
+++ b/workflow-dev/tpl/deis-controller-secret-django-secret-key.yaml
@@ -1,4 +1,4 @@
-#helm:generate helm tpl $HELM_GENERATE_DIR/tpl/deis-controller-secret-django-secret-key.yaml --out $HELM_GENERATE_DIR/manifests/deis-controller-secret-django-secret-key.yaml
+#helm:generate helm tpl --out $HELM_GENERATE_DIR/manifests/deis-controller-secret-django-secret-key.yaml $HELM_GENERATE_DIR/tpl/deis-controller-secret-django-secret-key.yaml
 apiVersion: v1
 kind: Secret
 metadata:

--- a/workflow-dev/tpl/deis-database-secret-creds.yaml
+++ b/workflow-dev/tpl/deis-database-secret-creds.yaml
@@ -1,4 +1,4 @@
-#helm:generate helm tpl $HELM_GENERATE_DIR/tpl/deis-database-secret-creds.yaml --out $HELM_GENERATE_DIR/manifests/deis-database-secret-creds.yaml
+#helm:generate helm tpl --out $HELM_GENERATE_DIR/manifests/deis-database-secret-creds.yaml $HELM_GENERATE_DIR/tpl/deis-database-secret-creds.yaml
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
The file argument is supposed to be the last argument, with the option list preceeding it. This
is causing some templates to be printed to stdout because --out is not set.
