### PR TITLE
chore(controller): Add default RESERVED_NAMES to chart

### DIFF
--- a/workflow-dev/tpl/deis-controller-rc.yaml
+++ b/workflow-dev/tpl/deis-controller-rc.yaml
@@ -60,6 +60,8 @@ spec:
                 secretKeyRef:
                   name: database-creds
                   key: password
+            - name: RESERVED_NAMES
+              value: "deis, deis-builder, deis-workflow-manager"
           volumeMounts:
             - mountPath: /var/run/docker.sock
               name: docker-socket


### PR DESCRIPTION
Complements deis/controller#662

This provides default values for the `RESERVED_NAMES` (application names that Workflow users may not use because Workflow itself uses them) in the chart where they can be modified by a cluster admin upon installation, instead of in the controller image where it was previously.

Also relates to https://github.com/deis/controller/issues/657
