### PR TITLE
feat(deis-builder-rc): get DEBUG from env or set to false

### DIFF
--- a/workflow-dev/tpl/deis-builder-rc.yaml
+++ b/workflow-dev/tpl/deis-builder-rc.yaml
@@ -40,7 +40,7 @@ spec:
             - name: "DOCKERIMAGE"
               value: "1"
             - name: "DEBUG"
-              value: "true"
+              value: "{{ env "DEBUG" | default "false" }}"
             - name: "POD_NAMESPACE"
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
This change was sparked by release procedures listed [here](http://docs-v2.readthedocs.io/en/latest/roadmap/release-checklist/#step-2-create-a-new-helm-chart).  Namely, it had been a manual process to be sure `DEBUG` was set to "false" for a release chart.  

This represents a solution wherein the default value will be "false" unless overridden via the local environment running a given chart.

To test this change:
1. verify a fresh install of `workflow-dev` produces no debug output on a builder action, for example, a `git push deis master` from an example app such as `example-go`:

```
helm generate workflow-dev
helm install workflow-dev
cd example-go
deis apps:create example-go
deis keys:add
git push deis master
```
1. verify a fresh install of `workflow-dev` with `DEBUG=true` on the generate step does cause debug output on same builder action:

```
helm uninstall workflow-dev -n deis -y
DEBUG=true helm generate workflow-dev
(repeat rest of steps above)
```
