### PR TITLE
feat(workflow-manager-rc): pull versionsApiURL from generate_params.toml

### DIFF
--- a/workflow-dev/tpl/deis-workflow-manager-rc.yaml
+++ b/workflow-dev/tpl/deis-workflow-manager-rc.yaml
@@ -28,9 +28,7 @@ spec:
         - name: WORKFLOW_MANAGER_PORT
           value: "8080"
         - name: WORKFLOW_MANAGER_VERSIONSAPIURL
-          value: "https://versions.deis.com"
-        - name: WORKFLOW_MANAGER_STAGINGAPIURL
-          value: "https://versions-staging.deis.com"
+          value: {{.workflowManager.versionsApiURL}}
         - name: WORKFLOW_MANAGER_DOCTORAPIURL
           value: "https://doctor.deis.com"
         - name: WORKFLOW_MANAGER_POLLING

--- a/workflow-dev/tpl/generate_params.toml
+++ b/workflow-dev/tpl/generate_params.toml
@@ -88,6 +88,7 @@ dockerTag = "canary"
 org = "deisci"
 pullPolicy = "Always"
 dockerTag = "canary"
+versionsApiURL = "https://versions-staging.deis.com"
 
 [logger]
 org = "deisci"


### PR DESCRIPTION
So that url may be changed from staging to prod via an update to `generate_params.toml` for a given release chart.

cc @jackfrancis @slack 
