### PR TITLE
Added k8s-home URL to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,4 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 [issues]: https://github.com/deis/charts/issues
 [prs]: https://github.com/deis/charts/pulls
+[k8s-home]: http://kubernetes.io


### PR DESCRIPTION
Trivial change. Link was missing.

For consistency, we could:
- change all the remote URLs to be at the bottom, like these 
- change the kubernetes one, I've just added to be an in-line link, like all the others.
