### PR TITLE
docs(*): Update docs and comments for helm classic

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![Build Status](https://travis-ci.org/deis/charts.svg?branch=master)](https://travis-ci.org/deis/charts)
 
-This repository contains Helm Charts for Deis, the open source PaaS company. Deis (pronounced DAY-iss) Workflow is an open source Platform as a Service (PaaS) that adds a developer-friendly layer to any [Kubernetes][k8s-home] cluster, making it easy to deploy and manage applications on your own servers.
+This repository contains Helm Classic Charts for Deis, the open source PaaS company. Deis (pronounced DAY-iss) Workflow is an open source Platform as a Service (PaaS) that adds a developer-friendly layer to any [Kubernetes][k8s-home] cluster, making it easy to deploy and manage applications on your own servers.
 
-For more information about Deis Workflow, please visit the main project page at https://github.com/deis/workflow. For more general-purpose Helm Charts, visit the [Helm Chart repository](https://github.com/helm/charts). To learn more about Helm, visit the [Helm repository](https://github.com/helm/helm).
+For more information about Deis Workflow, please visit the main project page at https://github.com/deis/workflow. For more general-purpose Helm Classic Charts, visit the [Helm Classic Chart repository](https://github.com/helm/charts). To learn more about Helm Classic, visit the [Helm Classic repository](https://github.com/helm/helm-classic).
 
 ## Beta Status
 
@@ -22,7 +22,7 @@ The Deis project welcomes contributions from all developers. The high level proc
 
 ## Contributing
 
-First, add this Chart repo to Helm to install the current "workflow-dev" chart:
+First, add this Chart repo to Helm Classic to install the current "workflow-dev" chart:
 
 ### Prerequisites
 
@@ -36,14 +36,14 @@ you can also do `ENABLE_DAEMONSETS=true` before running the `kube-up.sh` script.
 
 ### Installation
 
-First, add this Chart repo to Helm to install the "workflow" chart:
+First, add this Chart repo to Helm Classic to install the "workflow" chart:
 
 ```console
-$ helm repo add deis https://github.com/deis/charts
-$ helm up
-$ helm fetch deis/workflow-dev
-$ helm generate workflow-dev  # creates the required secrets
-$ helm install workflow-dev
+$ helmc repo add deis https://github.com/deis/charts
+$ helmc up
+$ helmc fetch deis/workflow-dev
+$ helmc generate workflow-dev  # creates the required secrets
+$ helmc install workflow-dev
 $ kubectl --namespace=deis get pods -w # watch this until all pods show "Running"
 $ kubectl --namespace=deis get svc deis-router
 # note the "EXTERNAL_IP" field for IP address on GKE/GCE/AWS, on Vagrant look for an "IP(S)"

--- a/workflow-beta1-e2e/README.md
+++ b/workflow-beta1-e2e/README.md
@@ -2,11 +2,11 @@
 
 End-to-end tests for the Deis v2 open source PaaS.
 
-NOTE: This assumes a fresh `helm install` of Deis v2. The test suite creates
+NOTE: This assumes a fresh `helmc install` of Deis v2. The test suite creates
 an initial user with admin privileges (who is deleted when tests complete).
 See https://github.com/deis/workflow-e2e for more detail.
 
 ```console
-$ helm install deis-workflow-beta1-e2e
+$ helmc install deis-workflow-beta1-e2e
 $ kubectl --namespace=deis logs -f deis-workflow-beta1-e2e -c deis-e2e
 ```

--- a/workflow-beta1/README.md
+++ b/workflow-beta1/README.md
@@ -6,7 +6,7 @@ Please report any issues you find in testing Workflow to the appropriate GitHub 
 - builder: https://github.com/deis/builder
 - chart: https://github.com/deis/charts
 - database: https://github.com/deis/postgres
-- helm: https://github.com/helm/helm
+- helm classic: https://github.com/helm/helm-classic
 - minio: https://github.com/deis/minio
 - registry: https://github.com/deis/registry
 - router: https://github.com/deis/router

--- a/workflow-beta1/tpl/generate_params.toml
+++ b/workflow-beta1/tpl/generate_params.toml
@@ -7,7 +7,7 @@
 # In general, all object storage credentials must be able to read and write to
 # the container or bucket they are configured to use.
 #
-# When you change values in this file, make sure to re-run `helm generate`
+# When you change values in this file, make sure to re-run `helmc generate`
 # on this chart.
 
 # Set the storage backend

--- a/workflow-beta2-e2e/README.md
+++ b/workflow-beta2-e2e/README.md
@@ -2,11 +2,11 @@
 
 End-to-end tests for the Deis Workflow open source PaaS, executed in parallel.
 
-NOTE: This assumes a fresh `helm install` of Deis v2. The test suite creates
+NOTE: This assumes a fresh `helmc install` of Deis v2. The test suite creates
 an initial user with admin privileges (who is deleted when tests complete).
 See https://github.com/deis/workflow-e2e for more detail.
 
 ```console
-$ helm uninstall -n deis -y workflow-dev-e2e ; helm install workflow-dev-e2e
+$ helmc uninstall -n deis -y workflow-dev-e2e ; helmc install workflow-dev-e2e
 $ kubectl --namespace=deis logs -f workflow-dev-e2e tests
 ```

--- a/workflow-beta2/README.md
+++ b/workflow-beta2/README.md
@@ -6,7 +6,7 @@ Please report any issues you find in testing Workflow to the appropriate GitHub 
 - builder: https://github.com/deis/builder
 - chart: https://github.com/deis/charts
 - database: https://github.com/deis/postgres
-- helm: https://github.com/helm/helm
+- helm classic: https://github.com/helm/helm-classic
 - minio: https://github.com/deis/minio
 - registry: https://github.com/deis/registry
 - router: https://github.com/deis/router

--- a/workflow-beta2/tpl/generate_params.toml
+++ b/workflow-beta2/tpl/generate_params.toml
@@ -7,7 +7,7 @@
 # In general, all object storage credentials must be able to read and write to
 # the container or bucket they are configured to use.
 #
-# When you change values in this file, make sure to re-run `helm generate`
+# When you change values in this file, make sure to re-run `helmc generate`
 # on this chart.
 
 # Set the storage backend

--- a/workflow-beta3-e2e/README.md
+++ b/workflow-beta3-e2e/README.md
@@ -2,11 +2,11 @@
 
 End-to-end tests for the Deis Workflow open source PaaS, executed in parallel.
 
-NOTE: This assumes a fresh `helm install` of Deis v2. The test suite creates
+NOTE: This assumes a fresh `helmc install` of Deis v2. The test suite creates
 an initial user with admin privileges (who is deleted when tests complete).
 See https://github.com/deis/workflow-e2e for more detail.
 
 ```console
-$ helm uninstall -n deis -y workflow-beta3-e2e ; helm install workflow-beta3-e2e
+$ helmc uninstall -n deis -y workflow-beta3-e2e ; helmc install workflow-beta3-e2e
 $ kubectl --namespace=deis logs -f workflow-beta3-e2e tests
 ```

--- a/workflow-beta3/Chart.yaml
+++ b/workflow-beta3/Chart.yaml
@@ -10,4 +10,4 @@ details: |-
   Workflow is an open source PaaS that makes it easy to deploy and manage applications on your own
   servers. Workflow builds on Kubernetes to provide a lightweight, Heroku-inspired workflow.
 
-  Helm v0.6.0+ is required to use this chart.
+  Helm Classic v0.7.0+ is required to use this chart.

--- a/workflow-beta3/README.md
+++ b/workflow-beta3/README.md
@@ -2,13 +2,13 @@
 
 WARNING: this chart is for testing only! Features may not work, and there are likely to be bugs.
 
-Helm v0.6.0+ is required to use this chart.
+Helm Classic v0.7.0+ is required to use this chart.
 
 Please report any issues you find in testing Workflow to the appropriate GitHub repository:
 - builder: https://github.com/deis/builder
 - chart: https://github.com/deis/charts
 - database: https://github.com/deis/postgres
-- helm: https://github.com/helm/helm
+- helm classic: https://github.com/helm/helm-classic
 - minio: https://github.com/deis/minio
 - registry: https://github.com/deis/registry
 - router: https://github.com/deis/router

--- a/workflow-beta3/tpl/generate_params.toml
+++ b/workflow-beta3/tpl/generate_params.toml
@@ -7,7 +7,7 @@
 # In general, all object storage credentials must be able to read and write to
 # the container or bucket they are configured to use.
 #
-# When you change values in this file, make sure to re-run `helm generate`
+# When you change values in this file, make sure to re-run `helmc generate`
 # on this chart.
 
 # Set the storage backend

--- a/workflow-dev-e2e/README.md
+++ b/workflow-dev-e2e/README.md
@@ -2,11 +2,11 @@
 
 End-to-end tests for the Deis Workflow open source PaaS, executed in parallel.
 
-NOTE: This assumes a fresh `helm install` of Deis v2. The test suite creates
+NOTE: This assumes a fresh `helmc install` of Deis v2. The test suite creates
 an initial user with admin privileges (who is deleted when tests complete).
 See https://github.com/deis/workflow-e2e for more detail.
 
 ```console
-$ helm uninstall -n deis -y workflow-dev-e2e ; helm install workflow-dev-e2e
+$ helmc uninstall -n deis -y workflow-dev-e2e ; helmc install workflow-dev-e2e
 $ kubectl --namespace=deis logs -f workflow-dev-e2e tests
 ```

--- a/workflow-dev/README.md
+++ b/workflow-dev/README.md
@@ -6,7 +6,7 @@ Please report any issues you find in testing Workflow to the appropriate GitHub 
 - builder: https://github.com/deis/builder
 - chart: https://github.com/deis/charts
 - database: https://github.com/deis/postgres
-- helm: https://github.com/helm/helm
+- helm classic: https://github.com/helm/helm-classic
 - logger: https://github.com/deis/logger
 - minio: https://github.com/deis/minio
 - registry: https://github.com/deis/registry

--- a/workflow-dev/tpl/generate_params.toml
+++ b/workflow-dev/tpl/generate_params.toml
@@ -7,7 +7,7 @@
 # In general, all object storage credentials must be able to read and write to
 # the container or bucket they are configured to use.
 #
-# When you change values in this file, make sure to re-run `helm generate`
+# When you change values in this file, make sure to re-run `helmc generate`
 # on this chart.
 
 # Set the storage backend


### PR DESCRIPTION
Update all docs and comment in this repo to reflect that Helm Classic is now the correct tool for installation of all charts herein.
