### PR TITLE
feat(workflow-dev): annotate "keeper" manifests

### DIFF
--- a/workflow-dev/manifests/deis-namespace.yaml
+++ b/workflow-dev/manifests/deis-namespace.yaml
@@ -4,3 +4,5 @@ metadata:
   name: deis
   labels:
     heritage: deis
+  annotations:
+    helm-keep: "true"

--- a/workflow-dev/manifests/deis-registry-service.yaml
+++ b/workflow-dev/manifests/deis-registry-service.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: deis
   labels:
     heritage: deis
+  annotations:
+    helm-keep: "true"
 spec:
   ports:
     - name: http

--- a/workflow-dev/manifests/deis-router-service.yaml
+++ b/workflow-dev/manifests/deis-router-service.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: deis
   labels:
     heritage: deis
+  annotations:
+    helm-keep: "true"
 spec:
   type: LoadBalancer
   selector:


### PR DESCRIPTION
The `helm-keep: "true"` annotation will be used by newer versions of Helm Classic to leave the `Namespace` and deis-router and deis-registry `Service`s intact when installing or uninstalling the Chart.

TODO:
- [x] ~~create a documentation PR describing upgrade with `helm-keep`.~~ See deis/workflow#259.
- [x] create a jenkins-jobs (or chart-mate?) PR that ensures cluster teardown doesn't break
- [x] get broader consensus on whether these are the right manifests to `helm-keep`

~~Depends on helm/helm-classic#474.~~

Questions:
- Are these the only two manifests that are "keepers"? ~~(Maybe minio?)~~ Also registry-service.
- Is it possible to add this also to workflow-beta4? I know that's been cut already, but without the annotations existing, it won't help for those upgrading from workflow-beta4 -> workflow-rc1. 😞  I'd really like to make that happen but don't want to anger the semver gods.
- Is this a supportable stop-gap solution for Helm Classic, or an unforgivable hack? Make your voice heard at helm/helm-classic#474.
