### PR TITLE
feat(router): Make platformDomain configurable through toml

### DIFF
--- a/workflow-dev/tpl/deis-router-rc.yaml
+++ b/workflow-dev/tpl/deis-router-rc.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: deis
   labels:
     heritage: deis
+{{- if ne .router.platformDomain "" }}
+  annotations:
+    router.deis.io/nginx.platformDomain: {{ .router.platformDomain }}
+{{- end }}
 spec:
   replicas: 1
   selector:

--- a/workflow-dev/tpl/generate_params.toml
+++ b/workflow-dev/tpl/generate_params.toml
@@ -100,6 +100,7 @@ dockerTag = "canary"
 org = "deisci"
 pullPolicy = "Always"
 dockerTag = "canary"
+platformDomain = ""
 
 [fluentd]
 org = "deisci"


### PR DESCRIPTION
Once upon a time, the router's `router.deis.io/nginx.platformDomain` annotation was required, and set to `example.com` by default, but that tripped some people up and _requiring_ people to edit a chart made for a frustrating first-time installation experience, so we made it optional...

When it because optional, we had to start using regular expressions on the router's vhosts to try to match inbound requests (if and only if this annotation remained undefined). In a production environment, it's probably better to _not_ to use regexes for this-- both for performance reasons and to remove any small bit of ambiguity about what each vhost matches. I'd like to amend [this bit of doc](http://docs-v2.readthedocs.io/en/latest/managing-workflow/production-deployments/) to recommend defining the `platformDomain` for production deployments.

As a prelude to that, I'm submitting this PR that makes it possible, yet still optional, to set this in the `generate_params.toml`.
