### PR TITLE
fix(router-dev): Better parity with workflow-dev chart

### DIFF
--- a/router-dev/README.md
+++ b/router-dev/README.md
@@ -1,4 +1,4 @@
-# Deis Router 2.0.0-beta
+# Deis Router 2.0.0-dev
 
 WARNING: this chart is for testing only! Features may not work and there are likely to be bugs.
 

--- a/router-dev/manifests/deis-namespace.yaml
+++ b/router-dev/manifests/deis-namespace.yaml
@@ -4,3 +4,5 @@ metadata:
   name: deis
   labels:
     heritage: deis
+  annotations:
+    helm-keep: "true"

--- a/router-dev/manifests/deis-router-service.yaml
+++ b/router-dev/manifests/deis-router-service.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: deis
   labels:
     heritage: deis
+  annotations:
+    helm-keep: "true"
 spec:
   type: LoadBalancer
   selector:

--- a/router-dev/tpl/deis-router-rc.yaml
+++ b/router-dev/tpl/deis-router-rc.yaml
@@ -1,4 +1,4 @@
-#helm:generate helm template -o $HELM_GENERATE_DIR/manifests/deis-router-rc.yaml -d $HELM_GENERATE_DIR/tpl/generate_params.toml $HELM_GENERATE_DIR/tpl/deis-router-rc.yaml
+#helm:generate helm tpl -d $HELM_GENERATE_DIR/tpl/generate_params.toml -o $HELM_GENERATE_DIR/manifests/deis-router-rc.yaml $HELM_GENERATE_DIR/tpl/deis-router-rc.yaml
 apiVersion: v1
 kind: ReplicationController
 metadata:
@@ -6,6 +6,10 @@ metadata:
   namespace: deis
   labels:
     heritage: deis
+{{- if ne .router.platformDomain "" }}
+  annotations:
+    router.deis.io/nginx.platformDomain: {{ .router.platformDomain }}
+{{- end }}
 spec:
   replicas: 1
   selector:

--- a/router-dev/tpl/generate_params.toml
+++ b/router-dev/tpl/generate_params.toml
@@ -2,3 +2,4 @@
 org = "deisci"
 dockerTag = "canary"
 pullPolicy = "Always"
+platformDomain = ""


### PR DESCRIPTION
This PR is aimed at restoring parity between the router components found in the well-maintained `workflow-dev` chart and the somewhat neglected `router-dev` chart. This is a prelude to making `deisrel` cut updated standalone router charts with each release.

**EDIT:** Please note that any attempts to install from the `router-dev` chart may not go so smoothly until https://github.com/deis/router/pull/195 is merged, as it contains a fix for a critical router bug that only manifests when no routable services are defined-- i.e. currently only manifests when router is installed separately from the rest of Workflow.
