### PR TITLE
chore(workflow-rc2): releasing workflow-rc2(-e2e) and router-rc2- final images

### DIFF
--- a/router-rc2/tpl/generate_params.toml
+++ b/router-rc2/tpl/generate_params.toml
@@ -1,5 +1,5 @@
 [router]
-org = "deisci"
+org = "deis"
 pullPolicy = "IfNotPresent"
 dockerTag = "v2.0.0-rc2"
 platformDomain = ""

--- a/workflow-rc2-e2e/tpl/generate_params.toml
+++ b/workflow-rc2-e2e/tpl/generate_params.toml
@@ -1,4 +1,4 @@
 [e2e]
-org = "deisci"
+org = "deis"
 dockerTag = "v2.0.0-rc2"
 pullPolicy = "IfNotPresent"

--- a/workflow-rc2/tpl/generate_params.toml
+++ b/workflow-rc2/tpl/generate_params.toml
@@ -46,84 +46,84 @@ database_bucket = "your-database-bucket-name"
 builder_bucket = "your-builder-bucket-name"
 
 [minio]
-org = "deisci"
+org = "deis"
 pullPolicy = "IfNotPresent"
 dockerTag = "v2.0.0-rc2"
 
 [builder]
-org = "deisci"
+org = "deis"
 pullPolicy = "IfNotPresent"
 dockerTag = "v2.0.0-rc2"
 
 [slugbuilder]
-org = "deisci"
+org = "deis"
 pullPolicy = "IfNotPresent"
 dockerTag = "v2.0.0-rc2"
 
 [dockerbuilder]
-org = "deisci"
+org = "deis"
 pullPolicy = "IfNotPresent"
 dockerTag = "v2.0.0-rc2"
 
 [controller]
-org = "deisci"
+org = "deis"
 pullPolicy = "IfNotPresent"
 dockerTag = "v2.0.0-rc2"
 
 [slugrunner]
-org = "deisci"
+org = "deis"
 pullPolicy = "IfNotPresent"
 dockerTag = "v2.0.0-rc2"
 
 [database]
-org = "deisci"
+org = "deis"
 pullPolicy = "IfNotPresent"
 dockerTag = "v2.0.0-rc2"
 
 [registry]
-org = "deisci"
+org = "deis"
 pullPolicy = "IfNotPresent"
 dockerTag = "v2.0.0-rc2"
 
 [workflowManager]
-org = "deisci"
+org = "deis"
 pullPolicy = "IfNotPresent"
 dockerTag = "v2.0.0-rc2"
 versionsApiURL = "https://versions.deis.com"
 doctorApiURL = "https://doctor.deis.com"
 
 [logger]
-org = "deisci"
+org = "deis"
 pullPolicy = "IfNotPresent"
 dockerTag = "v2.0.0-rc2"
 
 [router]
-org = "deisci"
+org = "deis"
 pullPolicy = "IfNotPresent"
 dockerTag = "v2.0.0-rc2"
 platformDomain = ""
 
 [fluentd]
-org = "deisci"
+org = "deis"
 pullPolicy = "IfNotPresent"
 dockerTag = "v2.0.0-rc2"
 
 [grafana]
-org = "deisci"
+org = "deis"
 pullPolicy = "IfNotPresent"
 dockerTag = "v2.0.0-rc2"
 
 [influxdb]
-org = "deisci"
+org = "deis"
 pullPolicy = "IfNotPresent"
 dockerTag = "v2.0.0-rc2"
 
 [telegraf]
-org = "deisci"
+org = "deis"
 pullPolicy = "IfNotPresent"
 dockerTag = "v2.0.0-rc2"
 
 [stdoutmetrics]
-org = "deisci"
+org = "deis"
 pullPolicy = "IfNotPresent"
 dockerTag = "v2.0.0-rc2"


### PR DESCRIPTION
This corrects the incorrect orgs that were pushed with the last commit-- quite by accident.
