### PR TITLE
ref(s3): keep the access key and secret key empty by default

### DIFF
--- a/workflow-dev/tpl/generate_params.toml
+++ b/workflow-dev/tpl/generate_params.toml
@@ -25,8 +25,10 @@ pullPolicy = "Always"
 dockerTag = "canary"
 
 [s3]
-accesskey = "YOUR KEY HERE"
-secretkey = "YOUR SECRET HERE"
+# Your AWS access key. Leave it empty if you want to use IAM credentials.
+accesskey = ""
+# Your AWS secret key. Leave it empty if you want to use IAM credentials.
+secretkey = ""
 # Any S3 region
 region = "us-west-1"
 # Your buckets.


### PR DESCRIPTION
It would be nice if can just leave them as empty instead of removing the existing value when user want's to use the instance profile option
