### PR TITLE
ref(workflow-dev): remove port 9090 from the service

### DIFF
--- a/workflow-dev/manifests/deis-router-service.yaml
+++ b/workflow-dev/manifests/deis-router-service.yaml
@@ -21,6 +21,3 @@ spec:
     - name: builder
       port: 2222
       targetPort: 2222
-    - name: healthz
-      port: 9090
-      targetPort: 9090


### PR DESCRIPTION
port 9090 is only used internally for healthchecks, and as far as I know no other components
have a reliance on router's uptime for their healthchecks. Therefore we should keep this internal and not expose it to the ELB.

ping @krancour for correctness. Are you aware of any other platform components that rely on the router's port 9090 being exposed in the service?
