### PR TITLE
fix(database): Fix logic for selecting off-cluster db

### DIFF
--- a/workflow-dev/tpl/deis-controller-rc.yaml
+++ b/workflow-dev/tpl/deis-controller-rc.yaml
@@ -53,13 +53,13 @@ spec:
                 secretKeyRef:
                   name: builder-key-auth
                   key: builder-key
-{{- if or (eq (env "DATABASE_LOCATION") "off-cluster") (eq .database_location "off-cluster") }}
+{{- if env "DATABASE_LOCATION" | default .database_location | eq "off-cluster" }}
             - name: DEIS_DATABASE_NAME
-              value: "{{ or (env "DATABASE_NAME") .database.name }}"
+              value: "{{ env "DATABASE_NAME" | default .database.name }}"
             - name: DEIS_DATABASE_SERVICE_HOST
-              value: "{{ or (env "DATABASE_HOST") .database.host }}"
+              value: "{{ env "DATABASE_HOST" | default .database.host }}"
             - name: DEIS_DATABASE_SERVICE_PORT
-              value: "{{ or (env "DATABASE_PORT") .database.port }}"
+              value: "{{ env "DATABASE_PORT" | default .database.port }}"
 {{- end }}
             - name: DEIS_DATABASE_USER
               valueFrom:

--- a/workflow-dev/tpl/deis-database-secret-creds.yaml
+++ b/workflow-dev/tpl/deis-database-secret-creds.yaml
@@ -7,5 +7,5 @@ metadata:
     app: deis-database
     heritage: deis
 data:
-  user: {{ if or (eq (env "DATABASE_LOCATION") "off-cluster") (eq .database_location "off-cluster") }}{{ or (env "DATABASE_USERNAME") .database.username | b64enc }}{{ else }}{{ randAlphaNum 32 | b64enc }}{{ end }}
-  password: {{ if or (eq (env "DATABASE_LOCATION") "off-cluster") (eq .database_location "off-cluster") }}{{ or (env "DATABASE_PASSWORD") .database.password | b64enc }}{{ else }}{{ randAlphaNum 32 | b64enc }}{{ end }}
+  user: {{ if env "DATABASE_LOCATION" | default .database_location | eq "off-cluster" }}{{ env "DATABASE_USERNAME" | default .database.username | b64enc }}{{ else }}{{ randAlphaNum 32 | b64enc }}{{ end }}
+  password: {{ if env "DATABASE_LOCATION" | default .database_location | eq "off-cluster" }}{{ env "DATABASE_PASSWORD" | default .database.password | b64enc }}{{ else }}{{ randAlphaNum 32 | b64enc }}{{ end }}

--- a/workflow-dev/tpl/storage.sh
+++ b/workflow-dev/tpl/storage.sh
@@ -8,10 +8,10 @@ else
 fi
 
 database_location=`grep "database_location\s*=\s*" $HELM_GENERATE_DIR/tpl/generate_params.toml | cut -d "=" -f2 | tr -dc '[:alnum:]-\n\r'`
-if [ "$DATABASE_LOCATION" = "off-cluster" ] || [ "$database_location" = "off-cluster" ]; then
-  rm -rf $HELM_GENERATE_DIR/manifests/deis-database-*
-else
+if [ "$DATABASE_LOCATION" = "on-cluster" ] || ( [ -z "$DATABASE_LOCATION" ] && [ "$database_location" = "on-cluster" ] ); then
   helmc tpl -d $HELM_GENERATE_DIR/tpl/generate_params.toml -o $HELM_GENERATE_DIR/manifests/deis-database-rc.yaml $HELM_GENERATE_DIR/tpl/deis-database-rc.yaml
   cp $HELM_GENERATE_DIR/tpl/deis-database-service* $HELM_GENERATE_DIR/manifests/
+else
+  rm -rf $HELM_GENERATE_DIR/manifests/deis-database-*
 fi
 helmc tpl -d $HELM_GENERATE_DIR/tpl/generate_params.toml -o $HELM_GENERATE_DIR/manifests/deis-database-secret-creds.yaml $HELM_GENERATE_DIR/tpl/deis-database-secret-creds.yaml


### PR DESCRIPTION
This corrects some minor bugs in the logic around configuring an off-cluster Postgres DB.

The bug in question is similar to that fixed by https://github.com/deis/charts/pull/298, so cc @kmala who is familiar with that change.
