### PR TITLE
wip: mirror workflow release artifacts to private registry

### DIFF
--- a/_scripts/mirror-images.sh
+++ b/_scripts/mirror-images.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# this script is built to pull Deis Worfklow release images, re-tag them and
+# subsequently push the images to a new repository
+
+# Usage: MIRROR_DESTINATION=quay.io/jhansen ./_script/mirror-images.sh
+
+# Override the version and source locations by setting the following
+# environment variables:
+WORKFLOW_IMAGE_SOURCE=${WORKFLOW_IMAGE_SOURCE:-quay.io}
+WORKFLOW_IMAGE_ORG=${WORKFLOW_IMAGE_ORG:-deis}
+WORKFLOW_RELEASE=${WORKLFOW_RELEASE:-v2.1.0}
+
+if [[ -z ${MIRROR_DESTINATION} ]]; then
+        echo "You must specify MIRROR_DESTINATION in your enviroment"
+        exit 1
+fi
+
+for image in builder \
+        controller \
+        dockerbuilder \
+        fluentd \
+        logger \
+        minio \
+        monitor \
+        postgres \
+        registry \
+        router \
+        slugbuilder \
+        slugrunner \
+        stdout-metrics \
+        workflow \
+        workflow-manager; do
+
+        source_image=${WORKFLOW_IMAGE_SOURCE}/${WORKFLOW_IMAGE_ORG}/$image:${WORKFLOW_RELEASE}
+        dest_image=${MIRROR_DESTINATION}/${image}:${WORKFLOW_RELEASE}
+
+        echo "Pulling image: ${source_image}"
+        docker pull ${source_image}
+
+        echo "Re-tagging image: ${source_image} to ${dest_image}"
+        docker tag ${source_image} ${dest_image}
+
+        echo "Pushing image: ${dest_image}"
+        docker push ${dest_image}
+done

--- a/workflow-v2.1.0/tpl/deis-builder-rc.yaml
+++ b/workflow-v2.1.0/tpl/deis-builder-rc.yaml
@@ -18,8 +18,8 @@ spec:
       serviceAccount: deis-builder
       containers:
         - name: deis-builder
-          image: quay.io/{{.builder.org}}/builder:{{ env "BUILDER_GIT_TAG" | default .builder.dockerTag}}
-          imagePullPolicy: {{.builder.pullPolicy}}
+          image: {{.builder.registry | default .images.registry}}/{{.builder.org | default .images.org}}/builder:{{env "BUILDER_GIT_TAG" | default .builder.dockerTag}}
+          imagePullPolicy: {{.builder.pullPolicy | default .images.pullPolicy}}
           ports:
             - containerPort: 2223
               name: ssh
@@ -36,9 +36,9 @@ spec:
             - name: "GIT_LOCK_TIMEOUT"
               value: "10"
             - name: "SLUGBUILDER_IMAGE_NAME"
-              value: "quay.io/{{.slugbuilder.org}}/slugbuilder:{{ env "SLUGBUILDER_GIT_TAG" | default .slugbuilder.dockerTag }}"
+              value: "{{.slugbuilder.registry | default .images.registry}}/{{.slugbuilder.org | default .images.org}}/slugbuilder:{{env "SLUGBUILDER_GIT_TAG" | default .slugbuilder.dockerTag }}"
             - name: "DOCKERBUILDER_IMAGE_NAME"
-              value: "quay.io/{{.dockerbuilder.org}}/dockerbuilder:{{ env "DOCKERBUILDER_GIT_TAG" | default .dockerbuilder.dockerTag}}"
+              value: "{{.dockerbuilder.registry | default .images.registry}}/{{.dockerbuilder.org | default .images.org}}/dockerbuilder:{{env "DOCKERBUILDER_GIT_TAG" | default .dockerbuilder.dockerTag}}"
             # This var needs to be passed so that the minio client (https://github.com/minio/mc) will work in Alpine linux
             - name: "DOCKERIMAGE"
               value: "1"

--- a/workflow-v2.1.0/tpl/deis-controller-rc.yaml
+++ b/workflow-v2.1.0/tpl/deis-controller-rc.yaml
@@ -18,8 +18,8 @@ spec:
       serviceAccount: deis-controller
       containers:
         - name: deis-controller
-          image: quay.io/{{.controller.org}}/controller:{{env "CONTROLLER_GIT_TAG" | default .controller.dockerTag}}
-          imagePullPolicy: {{.controller.pullPolicy}}
+          image: {{.controller.registry | default .images.registry}}/{{.controller.org | default .images.org}}/controller:{{env "CONTROLLER_GIT_TAG" | default .controller.dockerTag}}
+          imagePullPolicy: {{.controller.pullPolicy | default .images.pullPolicy}}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -40,7 +40,7 @@ spec:
             - name: "APP_STORAGE"
               value: "{{ or (env "STORAGE_TYPE") (.storage)}}"
             - name: "SLUGRUNNER_IMAGE_NAME"
-              value: "quay.io/{{.slugrunner.org}}/slugrunner:{{env "SLUGRUNNER_GIT_TAG" | default .slugrunner.dockerTag}}"
+              value: "{{.slugrunner.registry | default .images.registry}}/{{.slugrunner.org | default .images.org}}/slugrunner:{{env "SLUGRUNNER_GIT_TAG" | default .slugrunner.dockerTag}}"
             - name: DEIS_SECRET_KEY
               valueFrom:
                 secretKeyRef:

--- a/workflow-v2.1.0/tpl/deis-database-rc.yaml
+++ b/workflow-v2.1.0/tpl/deis-database-rc.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccount: deis-database
       containers:
         - name: deis-database
-          image: quay.io/{{.database.org}}/postgres:{{env "DATABASE_GIT_TAG" | default .database.dockerTag}}
+          image: {{.database.registry | default .images.registry}}/{{.database.org | default .images.registry}}/postgres:{{env "DATABASE_GIT_TAG" | default .database.dockerTag}}
           imagePullPolicy: {{.database.pullPolicy}}
           ports:
             - containerPort: 5432

--- a/workflow-v2.1.0/tpl/generate_params.toml
+++ b/workflow-v2.1.0/tpl/generate_params.toml
@@ -28,6 +28,11 @@ storage = "minio"
 # - off-cluster: Run PostgreSQL outside the Kubernetes cluster (configure in database section)
 database_location = "on-cluster"
 
+[images]
+registry = "quay.io"
+org = "deis"
+pullPolicy = "IfNotPresent"
+
 [minio]
 org = "deis"
 pullPolicy = "IfNotPresent"

--- a/workflow-v2.1.0/tpl/generate_params.toml
+++ b/workflow-v2.1.0/tpl/generate_params.toml
@@ -75,8 +75,6 @@ dockerTag = "v2.1.0"
 dockerTag = "v2.1.0"
 
 [controller]
-org = "deis"
-pullPolicy = "IfNotPresent"
 dockerTag = "v2.1.0"
 
 [slugrunner]

--- a/workflow-v2.1.0/tpl/generate_params.toml
+++ b/workflow-v2.1.0/tpl/generate_params.toml
@@ -81,8 +81,6 @@ dockerTag = "v2.1.0"
 dockerTag = "v2.1.0"
 
 [database]
-org = "deis"
-pullPolicy = "IfNotPresent"
 dockerTag = "v2.1.0"
 # Configure the following ONLY if using an off-cluster PostgreSQL database
 name = "database name"

--- a/workflow-v2.1.0/tpl/generate_params.toml
+++ b/workflow-v2.1.0/tpl/generate_params.toml
@@ -66,18 +66,12 @@ database_bucket = "your-database-bucket-name"
 builder_bucket = "your-builder-bucket-name"
 
 [builder]
-org = "deis"
-pullPolicy = "IfNotPresent"
 dockerTag = "v2.1.0"
 
 [slugbuilder]
-org = "deis"
-pullPolicy = "IfNotPresent"
 dockerTag = "v2.1.0"
 
 [dockerbuilder]
-org = "deis"
-pullPolicy = "IfNotPresent"
 dockerTag = "v2.1.0"
 
 [controller]
@@ -86,8 +80,6 @@ pullPolicy = "IfNotPresent"
 dockerTag = "v2.1.0"
 
 [slugrunner]
-org = "deis"
-pullPolicy = "IfNotPresent"
 dockerTag = "v2.1.0"
 
 [database]


### PR DESCRIPTION
Two parter. Spoke with some folks at Dockercon that needed to run Workflow in a internet-restricted enviroment. External access _must_ go through a proxy. They do have access to a private registry, so I wanted to see what it would take to make it much easier for someone to deploy Workflow in that environment.

First, create a little script to pull, re-tag and push release images to a different registry endpoint.

Second, re-work the charts to reference a defaults section for registry, org and pullPolicy values.

As I haven't gone through the release dance, I wanted thoughts on the general approach before completing the individual charts.

Does the chart refactorsimplify the relase tooling? Does it complicate workflow-dev and git-sha images?
