### PR TITLE
feat(workflow-e2e-pod.yaml): add CLI_VERSION to env

### DIFF
--- a/workflow-dev-e2e/tpl/workflow-e2e-pod.yaml
+++ b/workflow-dev-e2e/tpl/workflow-e2e-pod.yaml
@@ -17,6 +17,8 @@ spec:
         value: "{{env "GINKGO_NODES" | default 15}}"
       - name: JUNIT
         value: "true"
+      - name: CLI_VERSION
+        value: "{{env "CLI_VERSION" | default "latest"}}"
     volumeMounts:
     - name: artifact-volume
       mountPath: /root


### PR DESCRIPTION
So that a specific cli binary may be used in tests when running via chart

Ref https://github.com/deis/workflow-e2e/pull/260

cc @jchauncey @Joshua-Anderson 
