### PR TITLE
feat(test): add TEST env variable to workflow e2e chart

### DIFF
--- a/workflow-dev-e2e/tpl/workflow-e2e-pod.yaml
+++ b/workflow-dev-e2e/tpl/workflow-e2e-pod.yaml
@@ -19,6 +19,9 @@ spec:
         value: "true"
       - name: CLI_VERSION
         value: "{{env "CLI_VERSION" | default "latest"}}"
+       # set TEST env variable to run appropriate tests in e2e suite
+      - name: TEST
+        value: "{{env "TEST" | default "e2e"}}"
     volumeMounts:
     - name: artifact-volume
       mountPath: /root


### PR DESCRIPTION
make Ginkgo tests configurable via TEST env var, as workflow-e2e tests has more test suites piling up in the future this comes in handy.
refer https://github.com/deis/workflow-e2e/pull/263
