### PR TITLE
feat(workflow-dev): re-introduce registry-proxy

### DIFF
--- a/workflow-dev/tpl/deis-builder-deployment.yaml
+++ b/workflow-dev/tpl/deis-builder-deployment.yaml
@@ -32,13 +32,18 @@ spec:
             - containerPort: 8092
               name: healthsrv
           env:
+            # NOTE(bacongobbler): use deis/registry-proxy to work around Docker --insecure-registry requirements
+            - name: "DEIS_REGISTRY_SERVICE_HOST"
+              value: "localhost"
+            - name: "DEIS_REGISTRY_SERVICE_PORT"
+              value: "5555"
             - name: "HEALTH_SERVER_PORT"
               value: "8092"
             - name: "EXTERNAL_PORT"
               value: "2223"
             - name: BUILDER_STORAGE
               value: "{{ or (env "STORAGE_TYPE") (.storage)}}"
-            # Set GIT_LOCK_TIMEOUT to number of minutes you want to wait to git push again to the same repository 
+            # Set GIT_LOCK_TIMEOUT to number of minutes you want to wait to git push again to the same repository
             - name: "GIT_LOCK_TIMEOUT"
               value: "10"
             - name: "SLUGBUILDER_IMAGE_NAME"

--- a/workflow-dev/tpl/deis-controller-deployment.yaml
+++ b/workflow-dev/tpl/deis-controller-deployment.yaml
@@ -43,6 +43,11 @@ spec:
             - containerPort: 8000
               name: http
           env:
+            # NOTE(bacongobbler): use deis/registry-proxy to work around Docker --insecure-registry requirements
+            - name: "DEIS_REGISTRY_SERVICE_HOST"
+              value: "localhost"
+            - name: "DEIS_REGISTRY_SERVICE_PORT"
+              value: "5555"
             - name: KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS
               value: "5"
             - name: "APP_STORAGE"

--- a/workflow-dev/tpl/deis-registry-proxy-daemon.yaml
+++ b/workflow-dev/tpl/deis-registry-proxy-daemon.yaml
@@ -1,0 +1,36 @@
+#helm:generate helm tpl -d $HELM_GENERATE_DIR/tpl/generate_params.toml -o $HELM_GENERATE_DIR/manifests/deis-registry-proxy.yaml $HELM_GENERATE_FILE
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: deis-registry-proxy
+  namespace: deis
+  labels:
+    heritage: deis
+spec:
+  selector:
+    matchLabels:
+      app: deis-registry-proxy
+      heritage: deis
+  template:
+    metadata:
+      name: deis-registry-proxy
+      labels:
+        heritage: deis
+        app: deis-registry-proxy
+    spec:
+      containers:
+      - name: deis-registry-proxy
+        image: quay.io/{{.registry_proxy.org}}/registry-proxy:{{env "REGISTRY_PROXY_GIT_TAG" | default .registry_proxy.dockerTag}}
+        imagePullPolicy: {{.registry_proxy.pullPolicy}}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+        env:
+        - name: REGISTRY_HOST
+          value: $(DEIS_REGISTRY_SERVICE_HOST)
+        - name: REGISTRY_PORT
+          value: $(DEIS_REGISTRY_SERVICE_PORT)
+        ports:
+        - containerPort: 80
+          hostPort: 5555

--- a/workflow-dev/tpl/generate_params.toml
+++ b/workflow-dev/tpl/generate_params.toml
@@ -120,6 +120,11 @@ org = "deisci"
 pullPolicy = "Always"
 dockerTag = "canary"
 
+[registry_proxy]
+org = "deisci"
+pullPolicy = "Always"
+dockerTag = "canary"
+
 [workflowManager]
 org = "deisci"
 pullPolicy = "Always"


### PR DESCRIPTION
This re-introduces registry-proxy to the workflow components, though this time we are using
Docker's recommendations in docker/distribution's `contrib/` section.

See https://github.com/deis/registry-proxy

Note that this requires registry-proxy to be published to quay.io first before considering this ready to merge.

relies on https://github.com/deis/registry-proxy/pull/3 to be merged first before considering this ready for testing.

closes deis/registry-proxy#2
closes deis/workflow#385
