### PR TITLE
feat(minio): Add option to use hostPath for minio storage

### DIFF
--- a/workflow-dev/tpl/deis-minio-rc.yaml
+++ b/workflow-dev/tpl/deis-minio-rc.yaml
@@ -44,10 +44,19 @@ spec:
           args:
             - "server /home/minio/"
           volumeMounts:
+{{- if ne .minio.hostPath ""}}
+            - name: minio-home
+              mountPath: /home/minio
+{{- end }}
             - name: minio-user
               mountPath: /var/run/secrets/deis/minio/user
               readOnly: true
       volumes:
+{{- if ne .minio.hostPath ""}}
+        - name: minio-home
+          hostPath:
+            path: {{ .minio.hostPath }}
+{{- end }}
         - name: minio-user
           secret:
             secretName: objectstorage-keyfile

--- a/workflow-dev/tpl/generate_params.toml
+++ b/workflow-dev/tpl/generate_params.toml
@@ -69,6 +69,7 @@ hostname = ""
 org = "deisci"
 pullPolicy = "Always"
 dockerTag = "canary"
+hostPath = ""
 
 [s3]
 # Your AWS access key. Leave it empty if you want to use IAM credentials.


### PR DESCRIPTION
This adds an option to minio to set up a hostPath volume. Running deis in minikube is a use case.
