### PR TITLE
fix(minio): Pass the ip of the pod as env variable using downward api

### DIFF
--- a/workflow-dev/tpl/deis-minio-rc.yaml
+++ b/workflow-dev/tpl/deis-minio-rc.yaml
@@ -24,6 +24,10 @@ spec:
           env:
             - name: HEALTH_SERVER_PORT
               value: "8082"
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           ports:
             - containerPort: 9000
             - containerPort: 8082


### PR DESCRIPTION
fixes https://github.com/deis/minio/issues/42

the namespace is getting to default and hence can't find the pod https://github.com/deis/pkg/blob/master/aboutme/aboutme.go#L28
