### PR TITLE
feat(workflow-dev-e2e): add spotify/docker-gc to e2e

### DIFF
--- a/workflow-dev-e2e/manifests/spotify-gc-daemon.yaml
+++ b/workflow-dev-e2e/manifests/spotify-gc-daemon.yaml
@@ -17,7 +17,6 @@ spec:
         heritage: deis
         app: deis-spotify-gc
     spec:
-      serviceAccount: deis-spotify-gc
       containers:
       - name: deis-spotify-gc
         image: spotify/docker-gc:latest

--- a/workflow-dev-e2e/manifests/spotify-gc-daemon.yaml
+++ b/workflow-dev-e2e/manifests/spotify-gc-daemon.yaml
@@ -1,0 +1,31 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: deis-spotify-gc
+  namespace: deis
+  labels:
+    heritage: deis
+spec:
+  selector:
+    matchLabels:
+      app: deis-spotify-gc
+      heritage: deis
+  template:
+    metadata:
+      name: deis-spotify-gc
+      labels:
+        heritage: deis
+        app: deis-spotify-gc
+    spec:
+      serviceAccount: deis-spotify-gc
+      containers:
+      - name: deis-spotify-gc
+        image: spotify/docker-gc:latest
+        imagePullPolicy: Always
+        volumeMounts:
+        - mountPath: /var/run/docker.sock
+          name: docker-socket
+      volumes:
+      - name: docker-socket
+        hostPath:
+          path: /var/run/docker.sock


### PR DESCRIPTION
As seen in our GKE clusters, the docker images for the applications spawned by e2e
are never reaped. This causes thousands of images to persist, all identical to each other on a single
node and can trigger etcd issues.

See https://github.com/deis/controller/issues/1082#issuecomment-248079239 for some background context.
