### PR TITLE
feat(monitor): Make grafana credentials configurable

### DIFF
--- a/workflow-dev/tpl/deis-monitor-grafana-rc.yaml
+++ b/workflow-dev/tpl/deis-monitor-grafana-rc.yaml
@@ -35,6 +35,10 @@ spec:
           value: http://$(DEIS_MONITOR_INFLUXAPI_SERVICE_HOST):$(DEIS_MONITOR_INFLUXAPI_SERVICE_PORT_TRANSPORT)
         - name: "BIND_PORT"
           value: "3500"
+        - name: "DEFAULT_USER"
+          value: {{env "GRAFANA_USER" | default .grafana.user}}
+        - name: "DEFAULT_USER_PASSWORD"
+          value: {{env "GRAFANA_PASSWD" | default .grafana.password}}
         ports:
         - containerPort: 3500
           name: ui

--- a/workflow-dev/tpl/generate_params.toml
+++ b/workflow-dev/tpl/generate_params.toml
@@ -236,6 +236,8 @@ pullPolicy = "Always"
 dockerTag = "canary"
 # limits_cpu = "100m"
 # limits_memory = "50Mi"
+user = "admin"
+password = "admin"
 
 [influxdb]
 org = "deisci"


### PR DESCRIPTION
In the docs for Grafana it states:

> The default username/password of `admin/admin` can be overridden at any time by setting the following environment variables in `$CHART_HOME/workspace/workflow-$WORKFLOW_RELEASE/manifests/deis-monitor-grafana-rc.yaml`: `GRAFANA_USER` and `GRAFANA_PASSWD`.

For us it would be great if this was configurable via the template and/or environment variables.

This pull should make both options available.

I'd gladly make a pull as well for the docs, e.g:

> The default username/password of `admin/admin` can be overridden at any time by setting the following environment variables: `GRAFANA_USER` and `GRAFANA_PASSWD` or by editing the default parameters in `generate_params.toml` before running `helmc generate`.

Let me know if this is a way to go, or if I need to do anything differently!

Cheers.
