### PR TITLE
feat(scripts): automate some of workflow release

### DIFF
--- a/_scripts/new_workflow_charts.sh
+++ b/_scripts/new_workflow_charts.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -euo pipefail
+
+CHARTS="${CHARTS:-workflow-dev workflow-dev-e2e router-dev}"
+
+for chart in $CHARTS; do
+    new_chart=${chart/-dev/-$WORKFLOW_RELEASE}
+    echo "Creating $new_chart from $chart..."
+
+    # copy the workflow family of charts to their new home
+    cp -R -n "$chart"/ "$new_chart" || \
+        echo "Failed to copy files. Does $new_chart already exist?"
+
+    # update the controller deployment manifest
+    for f in $(find "$new_chart" -name deis-controller-deployment.yaml); do
+        # remove the k8s pod termination variable line and the one after
+        sed -i '' -e '/KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS/,/^/d' "$f"
+    done
+
+    # update the documentation files for production
+    for f in $(find "$new_chart" -name README.md -o -name Chart.yaml); do
+        # remove "WARNING: for testing only" lines
+        sed -i '' -e '/WARNING:/,/^/d' "$f"
+        sed -i '' -e 's/ (For testing only!)//g' "$f"
+        # collapse multiple blank lines into one
+        sed -i '' -e '/^$/N;/^\n$/D' "$f"
+        # replace all "dev" references with $WORKFLOW_RELEASE
+        sed -i '' -e "s/ dev/ $WORKFLOW_RELEASE/g" "$f"
+        sed -i '' -e "s/-dev/-$WORKFLOW_RELEASE/g" "$f"
+    done
+
+    # update the TOML parameters files
+    for f in $(find "$new_chart" -name generate_params.toml); do
+        # update all org values to "deis"
+        sed -i '' -e 's/"deisci"/"deis"/g' "$f"
+        # update the image pull policy to "IfNotPresent"
+        sed -i '' -e 's/"Always"/"IfNotPresent"/g' "$f"
+        # update the workflow manager URLs to production
+        sed -i '' -e 's/versions-staging/versions/g' "$f"
+        sed -i '' -e 's/doctor-staging/doctor/g' "$f"
+        # replace all "-dev" references with $WORKFLOW_RELEASE
+        sed -i '' -e "s/-dev/-$WORKFLOW_RELEASE/g" "$f"
+        # warn user to put semver tags in the generate_params.toml files
+        sed -i '' -e 's/"canary"/"CHANGEME"/g' "$f"
+        echo "$f needs semver values in \"dockerTag\" fields!"
+    done
+
+done

--- a/router-dev/Chart.yaml
+++ b/router-dev/Chart.yaml
@@ -1,6 +1,6 @@
 name: router-dev
 home: https://github.com/deis/router
-version: v2.0.0
+version: dev
 description: Deis Router (For testing only!)
 maintainers:
 - Deis Team <engineering@deis.com>

--- a/router-dev/README.md
+++ b/router-dev/README.md
@@ -1,4 +1,4 @@
-# Deis Router 2.0.0-dev
+# Deis Router dev
 
 WARNING: this chart is for testing only! Features may not work and there are likely to be bugs.
 

--- a/workflow-dev-e2e/Chart.yaml
+++ b/workflow-dev-e2e/Chart.yaml
@@ -1,6 +1,6 @@
 name: workflow-dev-e2e
 home: https://github.com/deis/workflow-e2e
-version: v2.0.0
+version: dev
 description: |-
   End-to-end tests for Deis Workflow, executed in parallel
 maintainers:

--- a/workflow-dev-e2e/README.md
+++ b/workflow-dev-e2e/README.md
@@ -1,4 +1,4 @@
-# Workflow 2.0.0-dev e2e Tests (parallel)
+# Workflow dev e2e Tests (parallel)
 
 End-to-end tests for the Deis Workflow open source PaaS, executed in parallel.
 


### PR DESCRIPTION
The `_scripts/new_workflow_charts.sh` shell script automates most of Workflow release [step 4](https://deis.com/docs/workflow/roadmap/releases/#step-4-create-helm-charts).

``` bash
$ WORKFLOW_RELEASE=v2.7.0 _scripts/new_workflow_charts.sh 
Creating workflow-v2.7.0 from workflow-dev...
workflow-v2.7.0/tpl/generate_params.toml needs semver values in "dockerTag" fields!
Creating workflow-v2.7.0-e2e from workflow-dev-e2e...
workflow-v2.7.0-e2e/tpl/generate_params.toml needs semver values in "dockerTag" fields!
Creating router-v2.7.0 from router-dev...
router-v2.7.0/tpl/generate_params.toml needs semver values in "dockerTag" fields!
```

Doc changes are in deis/workflow#530.
