### PR TITLE
fix(workflow-dev): bump router's livenessProbe initial delay

### DIFF
--- a/router-dev/tpl/deis-router-deployment.yaml
+++ b/router-dev/tpl/deis-router-deployment.yaml
@@ -49,7 +49,7 @@ spec:
           httpGet:
             path: /healthz
             port: 9090
-          initialDelaySeconds: 1
+          initialDelaySeconds: 10
           timeoutSeconds: 1
         readinessProbe:
           httpGet:

--- a/workflow-dev/tpl/deis-router-deployment.yaml
+++ b/workflow-dev/tpl/deis-router-deployment.yaml
@@ -60,7 +60,7 @@ spec:
           httpGet:
             path: /healthz
             port: 9090
-          initialDelaySeconds: 1
+          initialDelaySeconds: 10
           timeoutSeconds: 1
         readinessProbe:
           httpGet:


### PR DESCRIPTION
When there are a large number of applications and domains, the router can take some time to build.
In this time it makes sense to remove it from service, but not force it to restart. Bumping the
livenessProbe's initialDelay to 10 seconds should allow most general use cases through.

closes deis/router#212
