### PR TITLE
fix(registry): make GCR REGISTRY_LOCATION value consistent

### DIFF
--- a/workflow-dev/tpl/deis-registry-secret.yaml
+++ b/workflow-dev/tpl/deis-registry-secret.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     deis.io/registry-location: "{{ or (env "REGISTRY_LOCATION") (.registry_location) }}"
 type: Opaque
-data: {{ if or (eq (env "REGISTRY_LOCATION") "gcs") (eq .registry_location "gcr") }}
+data: {{ if or (eq (env "REGISTRY_LOCATION") "gcr") (eq .registry_location "gcr") }}
   key.json: {{ or (env "GCR_KEY_JSON") (.gcr.key_json) | b64enc }}
   hostname: {{ or (env "GCR_HOSTNAME") (.gcr.hostname) | b64enc }}{{ else if or (eq (env "REGISTRY_LOCATION") "ecr") (eq .registry_location "ecr") }}
   accesskey: {{ or (env "ECR_ACCESS_KEY") (.ecr.accesskey) | b64enc }}


### PR DESCRIPTION
The comments in `tpl/generate_params.toml` and the workflow registry
docs[1] state that the valid options for `registry_location` are:
`on-cluster`, `off-cluster`, `ecr`, `gcr`. This was correct when
`registry_location` is configured in `tpl/generate_params.toml`. When
defined by the `REGISTRY_LOCATION` enviroment variable, the value `gcs`
was accepted rather than `gcr`. This commit corrects this behavior so it
is consistent with both the documentation and the file-based definition.

[1] https://deis.com/docs/workflow/installing-workflow/configuring-registry/
