### PR TITLE
fix(workflow-dev/tpl/deis-database-deployment.yaml): rename env var

### DIFF
--- a/workflow-dev/tpl/deis-database-deployment.yaml
+++ b/workflow-dev/tpl/deis-database-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     heritage: deis
   annotations:
     helm-keep: "true"
-    component.deis.io/version: {{env "DATABASE_GIT_TAG" | default .database.dockerTag}}
+    component.deis.io/version: {{env "POSTGRES_GIT_TAG" | default .database.dockerTag}}
 spec:
   replicas: 1
   strategy:
@@ -23,7 +23,7 @@ spec:
       serviceAccount: deis-database
       containers:
         - name: deis-database
-          image: quay.io/{{.database.org}}/postgres:{{env "DATABASE_GIT_TAG" | default .database.dockerTag}}
+          image: quay.io/{{.database.org}}/postgres:{{env "POSTGRES_GIT_TAG" | default .database.dockerTag}}
           imagePullPolicy: {{.database.pullPolicy}}
           ports:
             - containerPort: 5432


### PR DESCRIPTION
from DATABASE_GIT_TAG to POSTGRES_GIT_TAG, so that when ci sets the latter in the env, it is properly used in the chart.