### PR TITLE
fix(workflow-dev): rewrite to avoid whitespace errors

### DIFF
--- a/workflow-dev/tpl/deis-database-deployment.yaml
+++ b/workflow-dev/tpl/deis-database-deployment.yaml
@@ -27,6 +27,13 @@ spec:
           imagePullPolicy: {{.database.pullPolicy}}
           ports:
             - containerPort: 5432
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - gosu
+                  - postgres
+                  - do_backup
           env:
             - name: DATABASE_STORAGE
               value: "{{ or (env "STORAGE_TYPE") (.storage)}}"
@@ -48,13 +55,6 @@ spec:
                 - is_running
             initialDelaySeconds: 30
             timeoutSeconds: 1
-          lifecycle:
-            preStop:
-              exec:
-                commmand:
-                  - gosu
-                  - postgres
-                  - do_backup
           volumeMounts:
             - name: database-creds
               mountPath: /var/run/secrets/deis/database/creds


### PR DESCRIPTION
YAML is picky and `kubectl` validation was failing on this manifest. I recreated the stanza and now it installs cleanly. Also `command` was misspelled with 3 `m`s.